### PR TITLE
[FIL-910] Re-structured front-end navigation to enable multiple views of different types of Applications

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,109 +1,11 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
-import { useState } from 'react';
+import dynamic from 'next/dynamic';
 
-import { ApplicationsPanel, DashboardHeader } from '@/components/dashboard';
-import Pagination from '@/components/Pagination';
-import { fetchApplications } from '@/lib/api';
-import Account from '@/components/account/Account';
-import ScaleLoader from 'react-spinners/ScaleLoader';
-import { DashboardBreadcrumb } from '@/components/dashboard/DashboardBreadcrumb';
-import { env } from '@/config/environment';
-import { Button } from '@/components/ui/button';
-import Link from 'next/link';
-import { RefreshAllocatorSection } from '@/components/refresh/RefreshAllocatorSection';
-import { useAccountRole } from '@/hooks/useAccountRole';
-import { AccountRole } from '@/types/account';
+const DashboardComponent = dynamic(() =>
+  import('@/components/dashboard').then(mod => mod.DashboardPage),
+);
 
-const PAGE_SIZE = 10;
-
-/**
- * DashboardPage component
- * Renders the main dashboard page with sidebar, header, and applications panel
- */
 export default function DashboardPage() {
-  const [searchTerm, setSearchTerm] = useState('');
-  const [activeFilters, setActiveFilters] = useState<string[]>([]);
-  const [currentPage, setCurrentPage] = useState(1);
-  const role = useAccountRole();
-
-  const { data, isLoading, error } = useQuery({
-    queryKey: ['applications', searchTerm, activeFilters, currentPage],
-    queryFn: () => fetchApplications(searchTerm, activeFilters, currentPage, PAGE_SIZE),
-    refetchInterval: 1 * 1000, // Refetch every 1 seconds
-  });
-
-  const breadcrumbItems = [
-    { label: 'Dashboard', href: '/dashboard' },
-    { label: 'Applications', href: '/dashboard' },
-  ];
-
-  const applications = data?.applications || [];
-  const totalCount = data?.totalCount || 0;
-
-  return (
-    <>
-      <header className="sticky top-0 z-30 flex h-14 items-center gap-4 border-b bg-background px-4 sm:static sm:h-auto sm:border-0 sm:bg-transparent sm:px-6">
-        <DashboardBreadcrumb items={breadcrumbItems} />
-        {env.useTestData && (
-          <div className="bg-yellow-100 p-2 text-yellow-800">
-            Using test data in {env.apiBaseUrl} environment
-          </div>
-        )}
-        <div className="relative ml-auto flex-1 md:grow-0"></div>
-
-        <Account />
-
-        {role === AccountRole.ROOT_KEY_HOLDER ? <RefreshAllocatorSection /> : null}
-
-        <Button variant="outline">
-          <span className="sr-only sm:not-sr-only sm:whitespace-nowrap">
-            <Link
-              href="https://airtable.com/appVmASv3V2GIds6v/pagI08VGIVczU97wK/form"
-              target="_blank"
-            >
-              Apply To Become An Allocator
-            </Link>
-          </span>
-        </Button>
-      </header>
-
-      <DashboardHeader
-        searchTerm={searchTerm}
-        setSearchTerm={setSearchTerm}
-        activeFilters={activeFilters}
-        setActiveFilters={setActiveFilters}
-      />
-
-      <main className="grid flex-1 items-start gap-4 p-4 sm:px-6 sm:py-0 md:gap-8">
-        {isLoading && (
-          <div className="absolute inset-0 flex items-center justify-center">
-            <ScaleLoader />
-          </div>
-        )}
-        {error && (
-          <div className="absolute inset-0 flex items-center justify-center">
-            <div className="text-red-500 text-center">Error: {error.message}</div>
-          </div>
-        )}
-        {!isLoading && !error && (
-          <>
-            <ApplicationsPanel
-              applications={applications}
-              totalCount={totalCount}
-              currentPage={currentPage}
-              pageSize={PAGE_SIZE}
-            />
-            <Pagination
-              currentPage={currentPage}
-              totalCount={totalCount}
-              pageSize={PAGE_SIZE}
-              onPageChange={setCurrentPage}
-            />
-          </>
-        )}
-      </main>
-    </>
-  );
+  return <DashboardComponent />;
 }

--- a/src/components/account/Account.tsx
+++ b/src/components/account/Account.tsx
@@ -1,8 +1,8 @@
-import { Badge } from "@/components/ui/badge";
-import { useAccount } from "@/hooks/useAccount";
+import { Badge } from '@/components/ui/badge';
+import { useAccount } from '@/hooks';
 
-import AccountDropdown from "./AccountDropdown";
-import ConnectWalletButton from "../connect/ConnectWalletButton";
+import AccountDropdown from './AccountDropdown';
+import ConnectWalletButton from '../connect/ConnectWalletButton';
 
 export default function Account() {
   const { account, disconnect } = useAccount();

--- a/src/components/connect/ConnectWalletButton.tsx
+++ b/src/components/connect/ConnectWalletButton.tsx
@@ -1,9 +1,9 @@
-"use client";
+'use client';
 
-import React, { useState } from "react";
-import { Button } from "@/components/ui/button";
-import { useAccount } from "../../hooks/useAccount";
-import { ConnectWalletDialog } from "./ConnectWalletDialog";
+import React, { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { useAccount } from '@/hooks';
+import { ConnectWalletDialog } from './ConnectWalletDialog';
 
 export default function ConnectWalletButton() {
   const { account, disconnect } = useAccount();
@@ -26,11 +26,7 @@ export default function ConnectWalletButton() {
   return (
     <>
       <Button onClick={() => setIsOpen(true)}>Connect Wallet</Button>
-      <ConnectWalletDialog
-        isOpen={isOpen}
-        setIsOpen={setIsOpen}
-        handleClose={handleClose}
-      />
+      <ConnectWalletDialog isOpen={isOpen} setIsOpen={setIsOpen} handleClose={handleClose} />
     </>
-  )
+  );
 }

--- a/src/components/connect/screens/MetamaskConnectionScreen.tsx
+++ b/src/components/connect/screens/MetamaskConnectionScreen.tsx
@@ -1,27 +1,27 @@
-import { useEffect } from "react";
-import { Loader2 } from "lucide-react";
+import { useEffect } from 'react';
+import { Loader2 } from 'lucide-react';
 
-import { useAccount } from "@/hooks/useAccount";
+import { useAccount } from '@/hooks';
 
 interface MetamaskConnectionScreenProps {
-    onConnect: () => void;
+  onConnect: () => void;
 }
 
 export const MetamaskConnectionScreen = ({ onConnect }: MetamaskConnectionScreenProps) => {
-    const { account, connect } = useAccount();
+  const { account, connect } = useAccount();
 
-    useEffect(() => {
-        if (account) {
-            onConnect();
-        } else {
-            connect("metamask", 0);
-        }
-    }, [account]);
+  useEffect(() => {
+    if (account) {
+      onConnect();
+    } else {
+      connect('metamask', 0);
+    }
+  }, [account]);
 
-    return (
-        <div className="flex flex-col items-center space-y-4">
-          <Loader2 className="h-8 w-8 animate-spin" />
-          <p>Connecting to MetaMask...</p>
-        </div>
-      );
-}
+  return (
+    <div className="flex flex-col items-center space-y-4">
+      <Loader2 className="h-8 w-8 animate-spin" />
+      <p>Connecting to MetaMask...</p>
+    </div>
+  );
+};

--- a/src/components/dashboard/DashboardHeader.test.tsx
+++ b/src/components/dashboard/DashboardHeader.test.tsx
@@ -1,0 +1,132 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { DashboardHeader } from './DashboardHeader';
+import userEvent from '@testing-library/user-event';
+
+describe('DashboardHeader', () => {
+  const defaultProps = {
+    searchTerm: '',
+    setSearchTerm: vi.fn(),
+    activeFilters: [],
+    availableFilters: ['KYC_PHASE', 'GOVERNANCE_REVIEW_PHASE', 'RKH_APPROVAL_PHASE'],
+    onFilterChange: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should display current search term in input', () => {
+    const searchText = 'test search';
+    render(<DashboardHeader {...defaultProps} searchTerm="test search" />);
+
+    const searchInput = screen.getByTestId('search-input');
+    expect(searchInput).toHaveValue(searchText);
+  });
+
+  it('should call setSearchTerm when search input changes', async () => {
+    const user = userEvent.setup();
+    const setSearchTerm = vi.fn();
+    const searchText = 'n';
+    render(<DashboardHeader {...defaultProps} setSearchTerm={setSearchTerm} />);
+
+    const searchInput = screen.getByTestId('search-input');
+    await user.type(searchInput, searchText);
+
+    expect(setSearchTerm).toHaveBeenCalledWith(searchText);
+  });
+
+  it('should not show filter count badge when no active filters', () => {
+    render(<DashboardHeader {...defaultProps} />);
+
+    const badge = screen.queryByTestId('count-badge');
+    expect(badge).not.toBeInTheDocument();
+  });
+
+  it('should show filter count badge when active filters exist', () => {
+    render(<DashboardHeader {...defaultProps} activeFilters={['KYC_PHASE', 'APPROVED']} />);
+
+    const badge = screen.getByTestId('count-badge');
+    expect(badge).toHaveTextContent('2');
+  });
+
+  it('should open filter dropdown when filter button is clicked', async () => {
+    const user = userEvent.setup();
+    render(<DashboardHeader {...defaultProps} />);
+
+    const filterButton = screen.getByRole('button', { name: /filters/i });
+    await user.click(filterButton);
+  });
+
+  it('should show checked state for active filters', async () => {
+    const user = userEvent.setup();
+    render(<DashboardHeader {...defaultProps} activeFilters={['KYC_PHASE']} />);
+
+    const filterButton = screen.getByRole('button', { name: /filters/i });
+    await user.click(filterButton);
+
+    const kycCheckbox = screen.getByRole('menuitemcheckbox', { name: 'KYC' });
+    expect(kycCheckbox).toHaveAttribute('data-state', 'checked');
+  });
+
+  it('should call onFilterChange when filter is toggled', async () => {
+    const user = userEvent.setup();
+    const onFilterChange = vi.fn();
+    render(<DashboardHeader {...defaultProps} onFilterChange={onFilterChange} />);
+
+    const filterButton = screen.getByRole('button', { name: /filters/i });
+    await user.click(filterButton);
+
+    const kycCheckbox = screen.getByRole('menuitemcheckbox', { name: 'KYC' });
+    await user.click(kycCheckbox);
+
+    expect(onFilterChange).toHaveBeenCalledWith('KYC_PHASE', true);
+  });
+
+  it('should call onFilterChange with false when unchecking active filter', async () => {
+    const user = userEvent.setup();
+    const onFilterChange = vi.fn();
+    render(
+      <DashboardHeader
+        {...defaultProps}
+        activeFilters={['KYC_PHASE']}
+        onFilterChange={onFilterChange}
+      />,
+    );
+
+    const filterButton = screen.getByRole('button', { name: /filters/i });
+    await user.click(filterButton);
+
+    const kycCheckbox = screen.getByRole('menuitemcheckbox', { name: 'KYC' });
+    await user.click(kycCheckbox);
+
+    expect(onFilterChange).toHaveBeenCalledWith('KYC_PHASE', false);
+  });
+
+  it('should render all filter labels correctly', async () => {
+    const user = userEvent.setup();
+    const allFilters = [
+      'KYC_PHASE',
+      'GOVERNANCE_REVIEW_PHASE',
+      'RKH_APPROVAL_PHASE',
+      'META_APPROVAL_PHASE',
+      'APPROVED',
+      'REJECTED',
+      'DC_ALLOCATED',
+    ];
+
+    render(<DashboardHeader {...defaultProps} availableFilters={allFilters} />);
+
+    const filterButton = screen.getByRole('button', { name: /filters/i });
+    await user.click(filterButton);
+
+    expect(screen.getByTestId('dropdown-label')).toHaveTextContent('Filter by status');
+    expect(screen.getByRole('menuitemcheckbox', { name: 'KYC' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitemcheckbox', { name: 'Governance Review' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitemcheckbox', { name: 'RKH Approval' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitemcheckbox', { name: 'Meta Approval' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitemcheckbox', { name: 'Approved' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitemcheckbox', { name: 'Rejected' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitemcheckbox', { name: 'DC Allocated' })).toBeInTheDocument();
+  });
+});

--- a/src/components/dashboard/DashboardHeader.tsx
+++ b/src/components/dashboard/DashboardHeader.tsx
@@ -1,6 +1,6 @@
-import { Search, ListFilter } from "lucide-react";
-import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
+import { ListFilter, Search } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -8,50 +8,42 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import MultipleSelector, { Option } from "@/components/ui/multiple-selector";
-import { Badge } from "@/components/ui/badge";
+} from '@/components/ui/dropdown-menu';
+import { Option } from '@/components/ui/multiple-selector';
+import { Badge } from '@/components/ui/badge';
 
 const OPTIONS: Option[] = [
-  { label: "SUBMISSION", value: "SUBMISSION" },
-  { label: "KYC", value: "KYC" },
-  { label: "GOVERNANCE_REVIEW", value: "GOVERNANCE_REVIEW" },
-  { label: "RKH_APPROVAL", value: "RKH_APPROVAL" },
+  { label: 'SUBMISSION', value: 'SUBMISSION' },
+  { label: 'KYC', value: 'KYC' },
+  { label: 'GOVERNANCE_REVIEW', value: 'GOVERNANCE_REVIEW' },
+  { label: 'RKH_APPROVAL', value: 'RKH_APPROVAL' },
 ];
 
 const FILTER_LABELS: Record<string, string> = {
-  KYC_PHASE: "KYC",
-  GOVERNANCE_REVIEW_PHASE: "Governance Review",
-  RKH_APPROVAL_PHASE: "RKH Approval",
-  META_APPROVAL_PHASE: "Meta Approval",
-  APPROVED: "Approved",
-  REJECTED: "Rejected",
-  DC_ALLOCATED: "DC Allocated",
+  KYC_PHASE: 'KYC',
+  GOVERNANCE_REVIEW_PHASE: 'Governance Review',
+  RKH_APPROVAL_PHASE: 'RKH Approval',
+  META_APPROVAL_PHASE: 'Meta Approval',
+  APPROVED: 'Approved',
+  REJECTED: 'Rejected',
+  DC_ALLOCATED: 'DC Allocated',
 };
 
 interface DashboardHeaderProps {
   searchTerm: string;
   setSearchTerm: (term: string) => void;
   activeFilters: string[];
-  setActiveFilters: (filters: string[]) => void;
+  availableFilters: string[];
+  onFilterChange: (filter: string, checked: boolean) => void;
 }
 
 export function DashboardHeader({
   searchTerm,
   setSearchTerm,
+  availableFilters,
   activeFilters,
-  setActiveFilters,
+  onFilterChange,
 }: DashboardHeaderProps) {
-  const filters: string[] = [
-    "KYC_PHASE",
-    "GOVERNANCE_REVIEW_PHASE",
-    "RKH_APPROVAL_PHASE",
-    "META_APPROVAL_PHASE",
-    "APPROVED",
-    "DC_ALLOCATED",
-    "REJECTED",
-  ];
-
   return (
     <header className="sticky top-0 z-30 flex h-14 items-center gap-4 border-b bg-background px-4 sm:static sm:h-auto sm:border-0 sm:bg-transparent sm:px-6">
       <div className="relative flex-1">
@@ -60,8 +52,9 @@ export function DashboardHeader({
           type="search"
           placeholder="Search by name..."
           className="w-full rounded-lg bg-background pl-8 md:w-[200px] lg:w-[320px]"
+          data-testid="search-input"
           value={searchTerm}
-          onChange={(e) => setSearchTerm(e.target.value)}
+          onChange={e => setSearchTerm(e.target.value)}
         />
       </div>
 
@@ -72,26 +65,24 @@ export function DashboardHeader({
               <ListFilter className="h-3.5 w-3.5" />
               <span className="sr-only sm:not-sr-only">Filters</span>
               {activeFilters.length > 0 && (
-                <Badge variant="secondary" className="ml-1 h-4 px-1 text-xs">
+                <Badge
+                  data-testid="count-badge"
+                  variant="secondary"
+                  className="ml-1 h-4 px-1 text-xs"
+                >
                   {activeFilters.length}
                 </Badge>
               )}
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="w-[250px]">
-            <DropdownMenuLabel>Filter by status</DropdownMenuLabel>
+            <DropdownMenuLabel data-testid="dropdown-label">Filter by status</DropdownMenuLabel>
             <DropdownMenuSeparator />
-            {filters.map((filter) => (
+            {availableFilters.map(filter => (
               <DropdownMenuCheckboxItem
                 key={filter}
                 checked={activeFilters.includes(filter)}
-                onCheckedChange={(checked) => {
-                  if (checked) {
-                    setActiveFilters([...activeFilters, filter]);
-                  } else {
-                    setActiveFilters(activeFilters.filter((f) => f !== filter));
-                  }
-                }}
+                onCheckedChange={checked => onFilterChange(filter, checked)}
               >
                 {FILTER_LABELS[filter]}
               </DropdownMenuCheckboxItem>

--- a/src/components/dashboard/DashboardPage.test.tsx
+++ b/src/components/dashboard/DashboardPage.test.tsx
@@ -11,7 +11,7 @@ const mocks = vi.hoisted(() => ({
   mockUseAccountRole: vi.fn(),
   mockUseAccount: vi.fn(),
   mockUseStateWaitMsg: vi.fn(),
-  useRKHTransaction: vi.fn(),
+  mockUseRKHTransaction: vi.fn(),
 }));
 
 vi.mock('@/hooks', () => ({
@@ -19,6 +19,7 @@ vi.mock('@/hooks', () => ({
   useGetApplications: mocks.mockUseGetApplications,
   useAccountRole: mocks.mockUseAccountRole,
   useStateWaitMsg: mocks.mockUseStateWaitMsg,
+  useRKHTransaction: mocks.mockUseRKHTransaction,
 }));
 
 vi.mock('@/config/environment', () => ({
@@ -57,7 +58,7 @@ describe('DashboardPage', () => {
       checkTransactionState: vi.fn(),
       stateWaitMsg: 'mockMessage',
     });
-    mocks.useRKHTransaction.mockReturnValue({
+    mocks.mockUseRKHTransaction.mockReturnValue({
       proposeTransaction: vi.fn(),
       messageId: 'mock-messageId',
     });

--- a/src/components/dashboard/DashboardPage.test.tsx
+++ b/src/components/dashboard/DashboardPage.test.tsx
@@ -1,0 +1,157 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { DashboardPage } from './DashboardPage';
+import { AccountRole } from '@/types/account';
+import { DashboardTabs } from '@/components/dashboard/constants';
+import { TooltipProvider } from '@/components/ui/tooltip';
+
+const mocks = vi.hoisted(() => ({
+  mockUseGetApplications: vi.fn(),
+  mockUseAccountRole: vi.fn(),
+  mockUseAccount: vi.fn(),
+  mockUseStateWaitMsg: vi.fn(),
+  useRKHTransaction: vi.fn(),
+}));
+
+vi.mock('@/hooks', () => ({
+  useAccount: mocks.mockUseAccount,
+  useGetApplications: mocks.mockUseGetApplications,
+  useAccountRole: mocks.mockUseAccountRole,
+  useStateWaitMsg: mocks.mockUseStateWaitMsg,
+}));
+
+vi.mock('@/config/environment', () => ({
+  env: {
+    useTestData: false,
+    apiBaseUrl: 'test-api',
+  },
+}));
+
+const mockApplicationsData = {
+  applications: [
+    { id: '1', name: 'Test App 1', status: 'NEW' },
+    { id: '2', name: 'Test App 2', status: 'KYC_PHASE' },
+  ],
+  totalCount: 2,
+};
+
+const mockAccount = {
+  address: '0x123...',
+  isConnected: true,
+  role: AccountRole.METADATA_ALLOCATOR,
+  wallet: { type: 'metamask' },
+};
+
+describe('DashboardPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mocks.mockUseAccount.mockReturnValue({ account: mockAccount });
+    mocks.mockUseAccountRole.mockReturnValue(AccountRole.METADATA_ALLOCATOR);
+    mocks.mockUseGetApplications.mockReturnValue({
+      data: mockApplicationsData,
+      error: null,
+    });
+    mocks.mockUseStateWaitMsg.mockReturnValue({
+      checkTransactionState: vi.fn(),
+      stateWaitMsg: 'mockMessage',
+    });
+    mocks.useRKHTransaction.mockReturnValue({
+      proposeTransaction: vi.fn(),
+      messageId: 'mock-messageId',
+    });
+  });
+
+  it('should render dashboard with basic elements for logged in user', () => {
+    render(<DashboardPage />, { wrapper: TooltipProvider });
+
+    expect(screen.getByRole('heading', { name: 'New Applications' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Apply To Become An Allocator' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'Avatar' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Completed Applications' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'New Applications' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Refreshes' })).toBeInTheDocument();
+  });
+
+  it('should show refresh section for root key holder', () => {
+    mocks.mockUseAccountRole.mockReturnValue(AccountRole.ROOT_KEY_HOLDER);
+
+    render(<DashboardPage />, { wrapper: TooltipProvider });
+
+    expect(screen.getByText('Refresh Allocator')).toBeInTheDocument();
+  });
+
+  it('should not show refresh section for regular allocator', () => {
+    render(<DashboardPage />, { wrapper: TooltipProvider });
+
+    expect(screen.queryByText('Refresh Allocator')).not.toBeInTheDocument();
+  });
+
+  it('should show connect wallet buttons for not logged user', () => {
+    mocks.mockUseAccount.mockReturnValue({ account: null });
+    render(<DashboardPage />, { wrapper: TooltipProvider });
+
+    const buttons = screen.getAllByRole('button', { name: 'Connect Wallet' });
+    expect(buttons).toHaveLength(2);
+  });
+
+  it('should switch tabs correctly', async () => {
+    const user = userEvent.setup();
+    render(<DashboardPage />, { wrapper: TooltipProvider });
+
+    const completedTab = screen.getByRole('tab', { name: 'Completed Applications' });
+    await user.click(completedTab);
+
+    expect(completedTab).toHaveAttribute('data-state', 'active');
+  });
+
+  it('should call useGetApplications with correct parameters on tab change', async () => {
+    const user = userEvent.setup();
+    render(<DashboardPage />, { wrapper: TooltipProvider });
+
+    expect(mocks.mockUseGetApplications).toHaveBeenCalledWith({
+      searchTerm: '',
+      activeFilters: [],
+      currentTab: DashboardTabs.NEW_APPLICATIONS,
+      currentPage: 1,
+    });
+
+    const completedTab = screen.getByRole('tab', { name: 'Completed Applications' });
+    await user.click(completedTab);
+
+    expect(mocks.mockUseGetApplications).toHaveBeenCalledWith({
+      searchTerm: '',
+      activeFilters: [],
+      currentTab: DashboardTabs.COMPLETED_APPLICATIONS,
+      currentPage: 1,
+    });
+  });
+
+  it('should display error when API fails', () => {
+    mocks.mockUseGetApplications.mockReturnValue({
+      data: null,
+      error: new Error('Network error'),
+    });
+
+    render(<DashboardPage />, { wrapper: TooltipProvider });
+
+    expect(screen.getByText('Error: Network error')).toBeInTheDocument();
+  });
+
+  it('should handle search term changes', async () => {
+    const user = userEvent.setup();
+    render(<DashboardPage />, { wrapper: TooltipProvider });
+
+    const searchInput = screen.getByPlaceholderText('Search by name...');
+    await user.type(searchInput, 'test');
+
+    expect(mocks.mockUseGetApplications).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        searchTerm: 'test',
+      }),
+    );
+  });
+});

--- a/src/components/dashboard/DashboardPage.tsx
+++ b/src/components/dashboard/DashboardPage.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import { Suspense, useEffect, useState } from 'react';
+
+import { ApplicationsPanel, DashboardHeader } from '@/components/dashboard';
+import Account from '@/components/account/Account';
+import ScaleLoader from 'react-spinners/ScaleLoader';
+import { DashboardBreadcrumb } from '@/components/dashboard/DashboardBreadcrumb';
+import { env } from '@/config/environment';
+import { Button } from '@/components/ui/button';
+import Link from 'next/link';
+import { RefreshAllocatorSection } from '@/components/refresh/RefreshAllocatorSection';
+import { AccountRole } from '@/types/account';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { availableFilters, DashboardTabs } from '@/components/dashboard/constants';
+import { useAccountRole, useGetApplications } from '@/hooks';
+
+/**
+ * DashboardPage component
+ * Renders the main dashboard page with sidebar, header, and applications panel
+ */
+export function DashboardPage() {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [activeFilters, setActiveFilters] = useState<string[]>([]);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [tab, setTab] = useState<DashboardTabs>(DashboardTabs.NEW_APPLICATIONS);
+  const role = useAccountRole();
+
+  const { data, error } = useGetApplications({
+    searchTerm,
+    activeFilters,
+    currentTab: tab,
+    currentPage,
+  });
+
+  const breadcrumbItems = [
+    { label: 'Dashboard', href: '/dashboard' },
+    { label: 'Applications', href: '/dashboard' },
+  ];
+
+  const applications = data?.applications || [];
+  const totalCount = data?.totalCount || 0;
+
+  const handleFilterChange = (filter: string, checked: boolean) => {
+    if (checked) {
+      setActiveFilters(prev => [...prev, filter]);
+    } else {
+      setActiveFilters(prev => prev.filter(f => f !== filter));
+    }
+  };
+
+  useEffect(() => {
+    setActiveFilters([]);
+    setCurrentPage(1);
+  }, [tab]);
+
+  return (
+    <>
+      <header className="sticky top-0 z-30 flex h-14 items-center gap-4 border-b bg-background px-4 sm:static sm:h-auto sm:border-0 sm:bg-transparent sm:px-6">
+        <DashboardBreadcrumb items={breadcrumbItems} />
+        {env.useTestData && (
+          <div className="bg-yellow-100 p-2 text-yellow-800">
+            Using test data in {env.apiBaseUrl} environment
+          </div>
+        )}
+        <div className="relative ml-auto flex-1 md:grow-0"></div>
+
+        <Account />
+
+        {role === AccountRole.ROOT_KEY_HOLDER ? <RefreshAllocatorSection /> : null}
+
+        <Button variant="outline">
+          <span className="sr-only sm:not-sr-only sm:whitespace-nowrap">
+            <Link
+              href="https://airtable.com/appVmASv3V2GIds6v/pagI08VGIVczU97wK/form"
+              target="_blank"
+            >
+              Apply To Become An Allocator
+            </Link>
+          </span>
+        </Button>
+      </header>
+
+      <DashboardHeader
+        availableFilters={availableFilters[tab]}
+        searchTerm={searchTerm}
+        setSearchTerm={setSearchTerm}
+        activeFilters={activeFilters}
+        onFilterChange={handleFilterChange}
+      />
+
+      <main className="grid flex-1 items-start gap-4 p-4 sm:px-6 sm:py-0 md:gap-8">
+        {error && (
+          <div className="absolute inset-0 flex items-center justify-center">
+            <div className="text-red-500 text-center">Error: {error.message}</div>
+          </div>
+        )}
+
+        <Tabs value={tab} onValueChange={value => setTab(value as DashboardTabs)}>
+          <TabsList className="w-full mt-4">
+            <TabsTrigger className="flex-1" value={DashboardTabs.NEW_APPLICATIONS}>
+              New Applications
+            </TabsTrigger>
+            <TabsTrigger className="flex-1" value={DashboardTabs.COMPLETED_APPLICATIONS}>
+              Completed Applications
+            </TabsTrigger>
+            <TabsTrigger className="flex-1" value={DashboardTabs.REFRESHES}>
+              Refreshes
+            </TabsTrigger>
+          </TabsList>
+
+          <Suspense
+            fallback={
+              <div className="absolute inset-0 flex items-center justify-center">
+                <ScaleLoader />
+              </div>
+            }
+          >
+            <TabsContent value={DashboardTabs.NEW_APPLICATIONS}>
+              <ApplicationsPanel
+                title="New Applications"
+                description="Consult and manage Fil+ program applications."
+                applications={applications}
+                totalCount={totalCount}
+                currentPage={currentPage}
+                onPageChange={setCurrentPage}
+              />
+            </TabsContent>
+            <TabsContent value={DashboardTabs.COMPLETED_APPLICATIONS}>
+              <ApplicationsPanel
+                title="Completed Applications"
+                description="Consult and manage Fil+ program applications."
+                applications={applications}
+                totalCount={totalCount}
+                currentPage={currentPage}
+                onPageChange={setCurrentPage}
+              />
+            </TabsContent>
+          </Suspense>
+        </Tabs>
+      </main>
+    </>
+  );
+}

--- a/src/components/dashboard/constants.ts
+++ b/src/components/dashboard/constants.ts
@@ -1,0 +1,19 @@
+export enum DashboardTabs {
+  NEW_APPLICATIONS = 'NEW',
+  COMPLETED_APPLICATIONS = 'COMPLETED',
+  REFRESHES = 'REFRESHES',
+}
+
+export const availableFilters: Record<DashboardTabs, string[]> = {
+  [DashboardTabs.NEW_APPLICATIONS]: [
+    'KYC_PHASE',
+    'GOVERNANCE_REVIEW_PHASE',
+    'RKH_APPROVAL_PHASE',
+    'APPROVED',
+    'META_APPROVAL_PHASE',
+  ],
+  [DashboardTabs.COMPLETED_APPLICATIONS]: ['DC_ALLOCATED', 'IN_REFRESSH', 'REJECTED'], // FIXME backend typo
+  [DashboardTabs.REFRESHES]: [],
+};
+
+export const PAGE_SIZE = 10;

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -1,3 +1,4 @@
-export * from "./panels/applications/ApplicationsPanel";
+export * from './panels/applications/ApplicationsPanel';
 export * from './DashboardHeader';
-export * from "./DashboardSidebar";
+export * from './DashboardSidebar';
+export * from './DashboardPage';

--- a/src/components/dashboard/panels/applications/ApplicationActionButton.tsx
+++ b/src/components/dashboard/panels/applications/ApplicationActionButton.tsx
@@ -1,29 +1,29 @@
-import { Application } from "@/types/application";
-import { Button } from "../../../ui/button";
-import Link from "next/link";
-import { useAccount } from "@/hooks/useAccount";
-import { AccountRole } from "@/types/account";
-import SignRkhTransactionButton from "@/components/sign/SignRkhTransactionButton";
-import SignMetaAllocatorTransactionButton from "@/components/sign/SignMetaAllocatorTransactionButton";
-import ApproveGovernanceReviewButton from "@/components/sign/ApproveGovernanceReviewButton";
-import { useState } from "react";
-import { ConnectWalletDialog } from "@/components/connect/ConnectWalletDialog";
-import OverrideKYCButton from "@/components/sign/OverrideKYCButton";
+import { Application } from '@/types/application';
+import { Button } from '../../../ui/button';
+import Link from 'next/link';
+import { useAccount } from '@/hooks';
+import { AccountRole } from '@/types/account';
+import SignRkhTransactionButton from '@/components/sign/SignRkhTransactionButton';
+import SignMetaAllocatorTransactionButton from '@/components/sign/SignMetaAllocatorTransactionButton';
+import ApproveGovernanceReviewButton from '@/components/sign/ApproveGovernanceReviewButton';
+import { useState } from 'react';
+import { ConnectWalletDialog } from '@/components/connect/ConnectWalletDialog';
+import OverrideKYCButton from '@/components/sign/OverrideKYCButton';
 
 interface ActionConfig {
   label: string;
   href?: string;
   disabled?: boolean;
   component?: React.ComponentType<any>;
-  connectWallet?: boolean; 
+  connectWallet?: boolean;
 }
 
 function getActionConfig(application: Application, account?: { role: AccountRole }): ActionConfig {
   const { status, id, githubPrNumber } = application;
-  let label = ""
+  let label = '';
 
   switch (status) {
-    case "KYC_PHASE":
+    case 'KYC_PHASE':
       // If gov team is logged in they can override KYC.
       // If not, the viewer can submit KYC
       if (account?.role === AccountRole.GOVERNANCE_TEAM || account?.role === AccountRole.ADMIN) {
@@ -33,12 +33,12 @@ function getActionConfig(application: Application, account?: { role: AccountRole
         };
       } else {
         return {
-          label: "Submit KYC",
+          label: 'Submit KYC',
           href: `https://verify.zyphe.com/flow/fil-kyc/kyc/kyc?applicationId=${application.id}`,
         };
       }
 
-    case "GOVERNANCE_REVIEW_PHASE":
+    case 'GOVERNANCE_REVIEW_PHASE':
       if (account?.role === AccountRole.GOVERNANCE_TEAM || account?.role === AccountRole.ADMIN) {
         return {
           label,
@@ -46,12 +46,12 @@ function getActionConfig(application: Application, account?: { role: AccountRole
         };
       } else {
         return {
-          label: "Connect Wallet",
+          label: 'Connect Wallet',
           connectWallet: true,
         } as ActionConfig & { connectWallet: true };
       }
 
-    case "RKH_APPROVAL_PHASE":
+    case 'RKH_APPROVAL_PHASE':
       label = `(${application.rkhApprovals?.length ?? 0}/${application.rkhApprovalsThreshold ?? 2}) Approve`;
       if (account?.role === AccountRole.ROOT_KEY_HOLDER || account?.role === AccountRole.ADMIN) {
         return {
@@ -60,38 +60,43 @@ function getActionConfig(application: Application, account?: { role: AccountRole
         };
       } else {
         return {
-          label: "Connect Wallet",
+          label: 'Connect Wallet',
           connectWallet: true,
         } as ActionConfig & { connectWallet: true };
       }
 
-    case "META_APPROVAL_PHASE":
-        if (account?.role === AccountRole.METADATA_ALLOCATOR || account?.role === AccountRole.ADMIN) {
-          return {
-            label: "Approve",
-            component: SignMetaAllocatorTransactionButton,
-          };
-        } else {
-          return {
-            label: "Connect Wallet",
-            connectWallet: true,
-          } as ActionConfig & { connectWallet: true };
-        }
-       
+    case 'META_APPROVAL_PHASE':
+      if (account?.role === AccountRole.METADATA_ALLOCATOR || account?.role === AccountRole.ADMIN) {
+        return {
+          label: 'Approve',
+          component: SignMetaAllocatorTransactionButton,
+        };
+      } else {
+        return {
+          label: 'Connect Wallet',
+          connectWallet: true,
+        } as ActionConfig & { connectWallet: true };
+      }
+
     default:
       return {
-        label: "Connect Wallet",
+        label: 'Connect Wallet',
         connectWallet: true,
       } as ActionConfig & { connectWallet: true };
   }
 }
 
-export function ApplicationActionButton({ application }: { application: Application }) {  
+export function ApplicationActionButton({ application }: { application: Application }) {
   const { account } = useAccount();
   const [isDialogOpen, setDialogOpen] = useState(false);
   const handleClose = () => setDialogOpen(false);
-  const { label, href, disabled, component: Component, connectWallet } = getActionConfig(application, { role: account?.role ?? AccountRole.GUEST });
-
+  const {
+    label,
+    href,
+    disabled,
+    component: Component,
+    connectWallet,
+  } = getActionConfig(application, { role: account?.role ?? AccountRole.GUEST });
 
   return (
     <>

--- a/src/components/dashboard/panels/applications/ApplicationStatusBadge.tsx
+++ b/src/components/dashboard/panels/applications/ApplicationStatusBadge.tsx
@@ -2,13 +2,8 @@ import React from 'react';
 import { cn } from '@/lib/utils';
 import { Application, ApplicationStatus } from '@/types/application';
 import { HelpCircle } from 'lucide-react';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import { Badge } from "@/components/ui/badge";
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { Badge } from '@/components/ui/badge';
 
 interface ApplicationStatusBadgeProps {
   application: Application;
@@ -22,6 +17,7 @@ const phaseColors: Record<ApplicationStatus, string> = {
   DC_ALLOCATED: 'bg-green-600',
   APPROVED: 'bg-green-600',
   REJECTED: 'bg-red-600',
+  IN_REFRESSH: 'bg-gray-600',
 };
 
 const phaseDescriptions: Record<ApplicationStatus, string> = {
@@ -32,6 +28,7 @@ const phaseDescriptions: Record<ApplicationStatus, string> = {
   DC_ALLOCATED: 'Datacap Allocated',
   APPROVED: 'Approved',
   REJECTED: 'Application rejected',
+  IN_REFRESSH: 'In Refresh',
 };
 
 const phaseNames: Record<ApplicationStatus, string> = {
@@ -42,26 +39,27 @@ const phaseNames: Record<ApplicationStatus, string> = {
   DC_ALLOCATED: 'DC Allocated',
   APPROVED: 'Approved',
   REJECTED: 'Rejected',
+  IN_REFRESSH: 'In Refresh',
 };
 
 export function ApplicationStatusBadge({ application }: ApplicationStatusBadgeProps) {
   return (
-          <Badge 
-            className={cn(
-              "text-xs font-semibold",
-              phaseColors[application.status],
-              'ring-2 ring-offset-2 ring-offset-white ring-gray-300'
-            )}
-          >
-            {phaseNames[application.status]}
-            <Tooltip>
+    <Badge
+      className={cn(
+        'text-xs font-semibold',
+        phaseColors[application.status],
+        'ring-2 ring-offset-2 ring-offset-white ring-gray-300',
+      )}
+    >
+      {phaseNames[application.status]}
+      <Tooltip>
         <TooltipTrigger asChild>
-            <HelpCircle className="w-4 h-4 text-white ml-2" />
-            </TooltipTrigger>
+          <HelpCircle className="w-4 h-4 text-white ml-2" />
+        </TooltipTrigger>
         <TooltipContent>
           <p>{phaseDescriptions[application.status]}</p>
         </TooltipContent>
       </Tooltip>
-          </Badge>
+    </Badge>
   );
 }

--- a/src/components/dashboard/panels/applications/ApplicationStatusBar.tsx
+++ b/src/components/dashboard/panels/applications/ApplicationStatusBar.tsx
@@ -1,27 +1,22 @@
 import React from 'react';
 import { cn } from '@/lib/utils';
 import { Application, ApplicationStatus } from '@/types/application';
-import { CheckCircle2, AlertCircle, Clock, XCircle, HelpCircle } from 'lucide-react';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import { Badge } from "@/components/ui/badge";
+import { AlertCircle, HelpCircle } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { Badge } from '@/components/ui/badge';
 
 interface ApplicationStatusBarProps {
   application: Application;
 }
 
 const phases: ApplicationStatus[] = [
-  "KYC_PHASE",
-  "GOVERNANCE_REVIEW_PHASE",
-  "RKH_APPROVAL_PHASE",
-  "META_APPROVAL_PHASE",
-  "APPROVED",
-  "DC_ALLOCATED",
-  "REJECTED",
+  'KYC_PHASE',
+  'GOVERNANCE_REVIEW_PHASE',
+  'RKH_APPROVAL_PHASE',
+  'META_APPROVAL_PHASE',
+  'APPROVED',
+  'DC_ALLOCATED',
+  'REJECTED',
 ];
 
 const phaseColors: Record<ApplicationStatus, string> = {
@@ -32,6 +27,7 @@ const phaseColors: Record<ApplicationStatus, string> = {
   DC_ALLOCATED: 'bg-green-600',
   APPROVED: 'bg-green-600',
   REJECTED: 'bg-red-600',
+  IN_REFRESSH: 'bg-gray-600',
 };
 
 const phaseDescriptions: Record<ApplicationStatus, string> = {
@@ -42,6 +38,7 @@ const phaseDescriptions: Record<ApplicationStatus, string> = {
   DC_ALLOCATED: 'Received DC',
   APPROVED: 'Application approved',
   REJECTED: 'Application rejected',
+  IN_REFRESSH: 'In refresh',
 };
 
 const phaseNames: Record<ApplicationStatus, string> = {
@@ -51,6 +48,7 @@ const phaseNames: Record<ApplicationStatus, string> = {
   META_APPROVAL_PHASE: 'Meta approval',
   DC_ALLOCATED: 'DC Allocated',
   APPROVED: 'Approved',
+  IN_REFRESSH: 'In Refresh',
   REJECTED: 'Rejected',
 };
 
@@ -70,15 +68,15 @@ export function ApplicationStatusBar({ application }: ApplicationStatusBarProps)
           <React.Fragment key={p}>
             <div
               className={cn(
-                "absolute h-2 rounded-full",
-                index <= currentPhaseIndex ? phaseColors[p] : 'bg-gray-300'
+                'absolute h-2 rounded-full',
+                index <= currentPhaseIndex ? phaseColors[p] : 'bg-gray-300',
               )}
               style={{
                 left: `${(index / (phases.length - 1)) * 100}%`,
                 width: `${100 / (phases.length - 1)}%`,
                 transform: `scaleX(${getPhaseProgress(index)})`,
                 transformOrigin: 'left',
-                transition: 'transform 0.3s ease-in-out'
+                transition: 'transform 0.3s ease-in-out',
               }}
             ></div>
             {index === currentPhaseIndex && (
@@ -86,12 +84,7 @@ export function ApplicationStatusBar({ application }: ApplicationStatusBarProps)
                 className="absolute -top-7 -translate-x-1/2"
                 style={{ left: `${(index / (phases.length - 1)) * 100}%` }}
               >
-                <Badge 
-                  className={cn(
-                    "text-xs font-semibold",
-                    phaseColors[p],
-                  )}
-                >
+                <Badge className={cn('text-xs font-semibold', phaseColors[p])}>
                   {phaseNames[p]}
                   <TooltipProvider>
                     <Tooltip>
@@ -108,8 +101,8 @@ export function ApplicationStatusBar({ application }: ApplicationStatusBarProps)
             )}
             <div
               className={cn(
-                "absolute top-1/2 w-3 h-3 rounded-full -translate-y-1/2 border-2 border-white",
-                index <= currentPhaseIndex ? phaseColors[p] : 'bg-gray-300'
+                'absolute top-1/2 w-3 h-3 rounded-full -translate-y-1/2 border-2 border-white',
+                index <= currentPhaseIndex ? phaseColors[p] : 'bg-gray-300',
               )}
               style={{ left: `calc(${(index / (phases.length - 1)) * 100}% - 6px)` }}
             ></div>
@@ -117,24 +110,24 @@ export function ApplicationStatusBar({ application }: ApplicationStatusBarProps)
         ))}
       </div>
       <div className="sm:hidden flex justify-center">
-        <Badge 
+        <Badge
           className={cn(
-            "text-xs font-semibold",
+            'text-xs font-semibold',
             phaseColors[application.status],
-            'ring-2 ring-offset-2 ring-offset-white ring-gray-300'
+            'ring-2 ring-offset-2 ring-offset-white ring-gray-300',
           )}
         >
           {phaseNames[application.status]}
           <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger asChild className="ml-2">
-                        <HelpCircle className="w-4 h-4 text-white" />
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        <p>{phaseDescriptions[application.status]}</p>
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild className="ml-2">
+                <HelpCircle className="w-4 h-4 text-white" />
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>{phaseDescriptions[application.status]}</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         </Badge>
       </div>
     </div>

--- a/src/components/dashboard/panels/applications/ApplicationsPanel.tsx
+++ b/src/components/dashboard/panels/applications/ApplicationsPanel.tsx
@@ -1,4 +1,4 @@
-import { Application } from "@/types/application";
+import { Application } from '@/types/application';
 import {
   Card,
   CardContent,
@@ -6,7 +6,7 @@ import {
   CardFooter,
   CardHeader,
   CardTitle,
-} from "@/components/ui/card";
+} from '@/components/ui/card';
 import {
   Table,
   TableBody,
@@ -14,174 +14,170 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from "@/components/ui/table";
+} from '@/components/ui/table';
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { Button } from "@/components/ui/button";
-import { CopyIcon, MoreHorizontal } from "lucide-react";
-import Link from "next/link";
-import { useToast } from "../../../ui/use-toast";
-import { ApplicationStatusBadge } from "./ApplicationStatusBadge";
-import { ApplicationActionButton } from "./ApplicationActionButton";
-import { useAccount } from "@/hooks";
-import { AccountRole } from "@/types/account";
-import { overrideKYC } from "@/lib/api";
-import OverrideKYCButton from "@/components/sign/OverrideKYCButton";
+} from '@/components/ui/dropdown-menu';
+import { Button } from '@/components/ui/button';
+import { CopyIcon, MoreHorizontal } from 'lucide-react';
+import Link from 'next/link';
+import { useToast } from '../../../ui/use-toast';
+import { ApplicationStatusBadge } from './ApplicationStatusBadge';
+import { ApplicationActionButton } from './ApplicationActionButton';
+import Pagination from '@/components/Pagination';
+import { PAGE_SIZE } from '@/components/dashboard/constants';
 
 interface ApplicationsPanelProps {
+  title: string;
+  description: string;
   applications: Application[];
   totalCount: number;
   currentPage: number;
-  pageSize: number;
+  onPageChange: (page: number) => void;
 }
 
 export function ApplicationsPanel({
   applications,
   totalCount,
   currentPage,
-  pageSize,
+  onPageChange,
+  title,
+  description,
 }: ApplicationsPanelProps) {
   const { toast } = useToast();
-  const { account } = useAccount()
-
-  const startIndex = (currentPage - 1) * pageSize + 1;
-  const endIndex = Math.min(startIndex + pageSize - 1, totalCount);
+  const startIndex = (currentPage - 1) * PAGE_SIZE + 1;
+  const endIndex = Math.min(startIndex + PAGE_SIZE - 1, totalCount);
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Applications</CardTitle>
-        <CardDescription>
-          Consult and manage Fil+ program applications.
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead className="hidden md:table-cell">#</TableHead>
-              <TableHead>Name</TableHead>
-              <TableHead className="hidden md:table-cell">Github</TableHead>
-              <TableHead className="hidden md:table-cell">Country</TableHead>
-              <TableHead className="hidden md:table-cell">DataCap</TableHead>
-              <TableHead>Phase</TableHead>
-              <TableHead>Action</TableHead>
-              <TableHead>
-                <span className="sr-only">Actions</span>
-              </TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {applications.map((application) => {
-              return (
-                <TableRow key={application.id}>
-                  <TableCell className="hidden md:table-cell font-medium">
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle>{title}</CardTitle>
+          <CardDescription>{description}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="hidden md:table-cell">#</TableHead>
+                <TableHead>Name</TableHead>
+                <TableHead className="hidden md:table-cell">Github</TableHead>
+                <TableHead className="hidden md:table-cell">Country</TableHead>
+                <TableHead className="hidden md:table-cell">DataCap</TableHead>
+                <TableHead>Phase</TableHead>
+                <TableHead>Action</TableHead>
+                <TableHead>
+                  <span className="sr-only">Actions</span>
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {applications.map(application => {
+                return (
+                  <TableRow key={application.id}>
+                    <TableCell className="hidden md:table-cell font-medium">
                       {application.githubPrNumber ? (
-                      <Link
-                        href={`${application.githubPrLink}`}
-                        target="_blank"
-                        className="text-blue-600 hover:text-blue-800 transition-colors underline"
-                      >
-                        {application.githubPrNumber}
-                      </Link>
-                    ) : (
-                      application.id
-                    )}
-                  </TableCell>
-                  <TableCell>{application.name}</TableCell>
-                  <TableCell className="hidden md:table-cell">
-                    <Link 
-                      href={`https://github.com/${application.github}`} 
-                      target="_blank"
-                      className="flex items-center text-blue-600 hover:text-blue-800 transition-colors"
-                    >
-                      <span className="underline">{application.github}</span>
-                    </Link>
-                  </TableCell>
-                  <TableCell className="hidden md:table-cell">
-                    {application.country}
-                  </TableCell>
-                  <TableCell className="hidden md:table-cell">
-                    {application.datacap} PiB
-                  </TableCell>
-                  <TableCell className="flex items-center">
-                    <ApplicationStatusBadge application={application} />
-                  </TableCell>
-                  <TableCell>
-                    <ApplicationActionButton application={application} />
-                  </TableCell>
-                  <TableCell className="flex items-center">
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <Button
-                          aria-haspopup="true"
-                          size="icon"
-                          variant="ghost"
+                        <Link
+                          href={`${application.githubPrLink}`}
+                          target="_blank"
+                          className="text-blue-600 hover:text-blue-800 transition-colors underline"
                         >
-                          <MoreHorizontal className="h-4 w-4" />
-                          <span className="sr-only">Toggle menu</span>
-                        </Button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent align="end">
-                        <DropdownMenuLabel>Actions</DropdownMenuLabel>
-                        {application.githubPrLink && (
-                          <DropdownMenuItem>
-                            <Link
-                              href={`${application.githubPrLink}`}
-                              target="_blank"
-                            >
-                              View PR
-                            </Link>
-                          </DropdownMenuItem>
-                        )}
-                        {application.status === 'KYC_PHASE' && (
-                          <DropdownMenuItem>
-                            <Link
-                            href={`https://verify.zyphe.com/flow/fil-kyc/kyc/kyc?applicationId=${application.id}`}
-                            target="_blank"
-                          >
-                            Submit KYC
-                          </Link>
-                          </DropdownMenuItem>
-                        )}
-                      </DropdownMenuContent>
-                    </DropdownMenu>
-                    <CopyIcon
-                      className="h-4 w-4 ml-2"
-                      onClick={async () => {
-                        try {
-                          await navigator.clipboard.writeText(application.id);
-                          toast({
-                            title: "Application ID copied",
-                            description:
-                              "The application ID has been copied to the clipboard.",
-                          });
-                        } catch (err) {
-                          console.error("Failed to copy text: ", err);
-                        }
-                      }}
-                    />
-                  </TableCell>
-                </TableRow>
-              );
-            })}
-          </TableBody>
-        </Table>
-      </CardContent>
-      <CardFooter>
-        <div className="text-xs text-muted-foreground">
-          Showing{" "}
-          <strong>
-            {startIndex}-{endIndex}
-          </strong>{" "}
-          of <strong>{totalCount}</strong> applications
-        </div>
-      </CardFooter>
-    </Card>
+                          {application.githubPrNumber}
+                        </Link>
+                      ) : (
+                        application.id
+                      )}
+                    </TableCell>
+                    <TableCell>{application.name}</TableCell>
+                    <TableCell className="hidden md:table-cell">
+                      <Link
+                        href={`https://github.com/${application.github}`}
+                        target="_blank"
+                        className="flex items-center text-blue-600 hover:text-blue-800 transition-colors"
+                      >
+                        <span className="underline">{application.github}</span>
+                      </Link>
+                    </TableCell>
+                    <TableCell className="hidden md:table-cell">{application.country}</TableCell>
+                    <TableCell className="hidden md:table-cell">
+                      {application.datacap} PiB
+                    </TableCell>
+                    <TableCell className="flex items-center">
+                      <ApplicationStatusBadge application={application} />
+                    </TableCell>
+                    <TableCell>
+                      <ApplicationActionButton application={application} />
+                    </TableCell>
+                    <TableCell className="flex items-center">
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button aria-haspopup="true" size="icon" variant="ghost">
+                            <MoreHorizontal className="h-4 w-4" />
+                            <span className="sr-only">Toggle menu</span>
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuLabel>Actions</DropdownMenuLabel>
+                          {application.githubPrLink && (
+                            <DropdownMenuItem>
+                              <Link href={`${application.githubPrLink}`} target="_blank">
+                                View PR
+                              </Link>
+                            </DropdownMenuItem>
+                          )}
+                          {application.status === 'KYC_PHASE' && (
+                            <DropdownMenuItem>
+                              <Link
+                                href={`https://verify.zyphe.com/flow/fil-kyc/kyc/kyc?applicationId=${application.id}`}
+                                target="_blank"
+                              >
+                                Submit KYC
+                              </Link>
+                            </DropdownMenuItem>
+                          )}
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                      <CopyIcon
+                        className="h-4 w-4 ml-2"
+                        onClick={async () => {
+                          try {
+                            await navigator.clipboard.writeText(application.id);
+                            toast({
+                              title: 'Application ID copied',
+                              description: 'The application ID has been copied to the clipboard.',
+                            });
+                          } catch (err) {
+                            console.error('Failed to copy text: ', err);
+                          }
+                        }}
+                      />
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </CardContent>
+        <CardFooter>
+          <div className="text-xs text-muted-foreground">
+            Showing{' '}
+            <strong>
+              {startIndex}-{endIndex}
+            </strong>{' '}
+            of <strong>{totalCount}</strong> applications
+          </div>
+        </CardFooter>
+      </Card>
+      <Pagination
+        currentPage={currentPage}
+        totalCount={totalCount}
+        pageSize={PAGE_SIZE}
+        onPageChange={onPageChange}
+      />
+    </>
   );
 }

--- a/src/components/refresh/RefreshAllocatorSection.test.tsx
+++ b/src/components/refresh/RefreshAllocatorSection.test.tsx
@@ -4,10 +4,12 @@ import { describe, expect, it, vi } from 'vitest';
 import { RefreshAllocatorSection } from './RefreshAllocatorSection';
 import { createWrapper } from '@/test-utils';
 
+const mocks = vi.hoisted(() => ({
+  mockUseRKHTransaction: vi.fn(),
+}));
+
 vi.mock('@/hooks/useRKHTransaction', () => ({
-  useRKHTransaction: () => ({
-    proposeTransaction: vi.fn(),
-  }),
+  useRKHTransaction: mocks.mockUseRKHTransaction.mockReturnValue({ proposeTransaction: vi.fn() }),
 }));
 
 describe('RefreshAllocatorSection', () => {

--- a/src/components/refresh/dialogs/RefreshAllocatorDialog.tsx
+++ b/src/components/refresh/dialogs/RefreshAllocatorDialog.tsx
@@ -9,7 +9,6 @@ import {
 } from '@/components/ui/dialog';
 import { useEffect, useState } from 'react';
 import { FormFields } from '@/components/refresh/dialogs/RefreshAllocatorValidationRules';
-import { useRKHTransaction } from '@/hooks/useRKHTransaction';
 import {
   RefreshAllocatorErrorStep,
   RefreshAllocatorFormStep,
@@ -17,7 +16,7 @@ import {
   RefreshAllocatorSuccessStep,
 } from '@/components/refresh/steps';
 import { RefreshAllocatorSteps } from '@/components/refresh/steps/constants';
-import { useStateWaitMsg } from '@/hooks';
+import { useRKHTransaction, useStateWaitMsg } from '@/hooks';
 
 interface RefreshAllocatorButtonProps {
   open: boolean;

--- a/src/components/sign/SignRkhTransactionButton.tsx
+++ b/src/components/sign/SignRkhTransactionButton.tsx
@@ -1,18 +1,18 @@
-"use client";
+'use client';
 
-import React, { useState } from "react";
-import ScaleLoader from "react-spinners/ScaleLoader";
-import { ExternalLink } from "lucide-react";
+import React, { useState } from 'react';
+import ScaleLoader from 'react-spinners/ScaleLoader';
+import { ExternalLink } from 'lucide-react';
 
-import { Button } from "@/components/ui/button";
+import { Button } from '@/components/ui/button';
 import {
   Dialog,
   DialogContent,
   DialogDescription,
   DialogHeader,
   DialogTitle,
-} from "@/components/ui/dialog";
-import { useToast } from "@/components/ui/use-toast";
+} from '@/components/ui/dialog';
+import { useToast } from '@/components/ui/use-toast';
 import {
   Table,
   TableBody,
@@ -20,9 +20,9 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from "@/components/ui/table";
-import { useAccount } from "@/hooks/useAccount";
-import { Application } from "@/types/application";
+} from '@/components/ui/table';
+import { useAccount } from '@/hooks';
+import { Application } from '@/types/application';
 
 interface SignRkhTransactionButtonProps {
   application: Application;
@@ -43,15 +43,15 @@ export default function SignRkhTransactionButton({
     try {
       const messageId = await proposeAddVerifier(application.address, application.datacap);
       toast({
-        title: "RKH Transaction Proposed",
+        title: 'RKH Transaction Proposed',
         description: `Transaction proposed with message id: ${messageId}`,
       });
     } catch (error) {
       console.error('Error proposing verifier:', error);
       toast({
-        title: "Error",
-        description: "Failed to propose verifier",
-        variant: "destructive",
+        title: 'Error',
+        description: 'Failed to propose verifier',
+        variant: 'destructive',
       });
     }
     setIsPending(false);
@@ -64,19 +64,19 @@ export default function SignRkhTransactionButton({
       const messageId = await acceptVerifierProposal(
         application.address,
         application.datacap,
-        application.rkhApprovals ? application.rkhApprovals[0] : "",
-        application.rkhMessageId ?? 0
+        application.rkhApprovals ? application.rkhApprovals[0] : '',
+        application.rkhMessageId ?? 0,
       );
       toast({
-        title: "RKH Transaction Approved",
+        title: 'RKH Transaction Approved',
         description: `Transaction approved with message id: ${messageId}`,
       });
     } catch (error) {
       console.error('Error accepting verifier proposal:', error);
       toast({
-        title: "Error",
-        description: "Failed to accept verifier proposal",
-        variant: "destructive",
+        title: 'Error',
+        description: 'Failed to accept verifier proposal',
+        variant: 'destructive',
       });
     }
     setIsPending(false);
@@ -111,7 +111,7 @@ export default function SignRkhTransactionButton({
               </TableHeader>
               <TableBody>
                 <TableRow key="verifier">
-                  <TableCell>{"Verifier"}</TableCell>
+                  <TableCell>{'Verifier'}</TableCell>
                   <TableCell>
                     {application.actorId}
                     <a
@@ -125,7 +125,7 @@ export default function SignRkhTransactionButton({
                   </TableCell>
                 </TableRow>
                 <TableRow key="datacap">
-                  <TableCell>{"DataCap"}</TableCell>
+                  <TableCell>{'DataCap'}</TableCell>
                   <TableCell>{application.datacap} PiB</TableCell>
                 </TableRow>
               </TableBody>
@@ -133,15 +133,19 @@ export default function SignRkhTransactionButton({
           )}
         </div>
         <div className="flex justify-center">
-        <Button className="w-[150px]" disabled={isPending} onClick={() => {
-          if (application.rkhApprovals && application.rkhApprovals.length > 0) {
-            approveTransaction();
-          } else {
-            proposeTransaction();
-          }
-        }}>
-          {isPending ? "Submitting..." : "Submit"}
-        </Button>
+          <Button
+            className="w-[150px]"
+            disabled={isPending}
+            onClick={() => {
+              if (application.rkhApprovals && application.rkhApprovals.length > 0) {
+                approveTransaction();
+              } else {
+                proposeTransaction();
+              }
+            }}
+          >
+            {isPending ? 'Submitting...' : 'Submit'}
+          </Button>
         </div>
       </DialogContent>
     </Dialog>

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,6 @@
 export * from './useAutoRefreshData';
 export * from './useAccount';
 export * from './useStateWaitMsg';
+export * from './useGetApplications';
+export * from './useAccountRole';
+export * from './useRKHTransaction';

--- a/src/hooks/useGetApplication.test.ts
+++ b/src/hooks/useGetApplication.test.ts
@@ -1,0 +1,138 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';
+import { useGetApplications } from '@/hooks/useGetApplications';
+import { fetchApplications } from '@/lib/api';
+import { createWrapper } from '@/test-utils';
+import { DashboardTabs } from '@/components/dashboard/constants';
+
+vi.mock('@/lib/api');
+
+const mocks = vi.hoisted(() => ({
+  invalidateQueries: vi.fn(),
+  cancelQueries: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual = await vi.importActual('@tanstack/react-query');
+  return {
+    ...actual,
+    useQueryClient: () => mocks,
+  };
+});
+
+const mockFetchApplications = fetchApplications as Mock;
+
+describe('useGetApplications', () => {
+  const wrapper = createWrapper();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return initial state correctly', () => {
+    mockFetchApplications.mockResolvedValue({ applications: [], total: 0 });
+
+    const { result } = renderHook(
+      () =>
+        useGetApplications({
+          searchTerm: '',
+          activeFilters: [],
+          currentPage: 1,
+          currentTab: DashboardTabs.NEW_APPLICATIONS,
+        }),
+      { wrapper },
+    );
+
+    expect(result.current.isPending).toBe(true);
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isError).toBe(false);
+  });
+
+  it('should fetch applications with correct parameters', async () => {
+    const mockData = { applications: [], total: 0 };
+    mockFetchApplications.mockResolvedValue(mockData);
+
+    const { result } = renderHook(
+      () =>
+        useGetApplications({
+          searchTerm: 'test',
+          activeFilters: ['filter1'],
+          currentPage: 1,
+          currentTab: DashboardTabs.NEW_APPLICATIONS,
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockFetchApplications).toHaveBeenCalledWith('test', ['filter1'], 1, 10);
+    expect(result.current.data).toEqual(mockData);
+  });
+
+  it('should handle API errors', async () => {
+    const error = new Error('API Error');
+    mockFetchApplications.mockRejectedValue(error);
+
+    const { result } = renderHook(
+      () =>
+        useGetApplications({
+          searchTerm: 'test',
+          activeFilters: ['filter1'],
+          currentPage: 1,
+          currentTab: DashboardTabs.NEW_APPLICATIONS,
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error).toBe(error);
+  });
+
+  it('should cancel queries on unmounted', () => {
+    mockFetchApplications.mockResolvedValue({ applications: [], total: 0 });
+
+    const { unmount } = renderHook(
+      () =>
+        useGetApplications({
+          searchTerm: 'test',
+          activeFilters: ['filter1'],
+          currentPage: 1,
+          currentTab: DashboardTabs.NEW_APPLICATIONS,
+        }),
+      { wrapper },
+    );
+
+    unmount();
+
+    expect(mocks.cancelQueries).toHaveBeenCalledTimes(1);
+  });
+
+  it('should invalidate queries when tab changes to valid tabs', () => {
+    mockFetchApplications.mockResolvedValue({ applications: [], total: 0 });
+
+    const { rerender } = renderHook(
+      ({ currentTab }) =>
+        useGetApplications({
+          searchTerm: 'test',
+          activeFilters: ['filter1'],
+          currentPage: 1,
+          currentTab,
+        }),
+      {
+        wrapper,
+        initialProps: { currentTab: DashboardTabs.NEW_APPLICATIONS },
+      },
+    );
+
+    rerender({ currentTab: DashboardTabs.COMPLETED_APPLICATIONS });
+
+    expect(mocks.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['applications'],
+    });
+  });
+});

--- a/src/hooks/useGetApplications.ts
+++ b/src/hooks/useGetApplications.ts
@@ -1,0 +1,53 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { fetchApplications } from '@/lib/api';
+import { availableFilters, DashboardTabs, PAGE_SIZE } from '@/components/dashboard/constants';
+import { useEffect } from 'react';
+
+interface UseGetApplicationsProps {
+  searchTerm: string;
+  activeFilters: string[];
+  currentPage: number;
+  currentTab: DashboardTabs;
+}
+
+export function useGetApplications({
+  searchTerm,
+  activeFilters,
+  currentPage,
+  currentTab,
+}: UseGetApplicationsProps) {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (
+      [DashboardTabs.COMPLETED_APPLICATIONS, DashboardTabs.NEW_APPLICATIONS].includes(currentTab)
+    ) {
+      queryClient.invalidateQueries({
+        queryKey: ['applications'],
+      });
+    }
+
+    return () => {
+      queryClient.cancelQueries();
+    };
+  }, [
+    currentTab,
+    searchTerm,
+    activeFilters,
+    currentPage,
+    queryClient.invalidateQueries,
+    queryClient.cancelQueries,
+  ]);
+
+  return useQuery({
+    queryKey: ['applications', searchTerm, activeFilters, currentPage],
+    queryFn: () =>
+      fetchApplications(
+        searchTerm,
+        activeFilters.length ? activeFilters : availableFilters[currentTab],
+        currentPage,
+        PAGE_SIZE,
+      ),
+    refetchInterval: 1 * 1000 * 60,
+  });
+}

--- a/src/hooks/useRKHTransaction.test.ts
+++ b/src/hooks/useRKHTransaction.test.ts
@@ -1,10 +1,10 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';
-import { useRKHTransaction } from '@/hooks/useRKHTransaction';
-import { useAccount } from '@/hooks/useAccount';
+import { useRKHTransaction } from './useRKHTransaction';
+import { useAccount } from '@/hooks';
 import { createWrapper } from '@/test-utils';
 
-vi.mock('@/hooks/useAccount');
+vi.mock('@/hooks');
 
 const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 const mockUseAccount = useAccount as Mock;

--- a/src/hooks/useRKHTransaction.ts
+++ b/src/hooks/useRKHTransaction.ts
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
-import { useAccount } from '@/hooks/useAccount';
+import { useAccount } from '@/hooks';
 import { Application } from '@/types/application';
 
 interface UseRKHTransactionProps {

--- a/src/test-utils/query-client.tsx
+++ b/src/test-utils/query-client.tsx
@@ -4,13 +4,8 @@ import { ReactNode } from 'react';
 export const createWrapper = () => {
   const queryClient = new QueryClient({
     defaultOptions: {
-      queries: {
-        retry: false,
-        gcTime: 0,
-      },
-      mutations: {
-        retry: false,
-      },
+      queries: { retry: false },
+      mutations: { retry: false },
     },
   });
 

--- a/src/types/application.ts
+++ b/src/types/application.ts
@@ -1,4 +1,13 @@
-export type ApplicationStatus = "KYC_PHASE" | "GOVERNANCE_REVIEW_PHASE" | "RKH_APPROVAL_PHASE" | "APPROVED" | "META_APPROVAL_PHASE" | "DC_ALLOCATED" | "REJECTED";
+//FIXME there is a backend typo associated with IN_REFRESH status, it should be investigated before changing (database model and migrations)
+export type ApplicationStatus =
+  | 'KYC_PHASE'
+  | 'GOVERNANCE_REVIEW_PHASE'
+  | 'RKH_APPROVAL_PHASE'
+  | 'APPROVED'
+  | 'META_APPROVAL_PHASE'
+  | 'DC_ALLOCATED'
+  | 'REJECTED'
+  | 'IN_REFRESSH'; // backend typo
 
 export interface Application {
   id: string;
@@ -26,15 +35,15 @@ export interface Application {
 
   // GOVERNANCE REVIEW PHASE
   applicationInstructions?: {
-    method: string[],
-    timestamp: number,
-    datacap_amount: number,
-  }
+    method: string[];
+    timestamp: number;
+    datacap_amount: number;
+  };
 
   // KHK APPROVAL PHASE
   rkhApprovals?: string[];
   rkhApprovalsThreshold?: number;
-  rkhMessageId?: number
+  rkhMessageId?: number;
 }
 
 export interface ApplicationsResponse {


### PR DESCRIPTION
Added:
- Multiple tab views: New Applications, Completed Applications, Refreshes.
- The Refreshes tab is currently empty.
- Moved the dashboard page  component to a new location to simplify the tests
- Dynamic import added for the dashboard page.
- Tests for main functionality have been added.

Pictures:
![Screenshot from 2025-06-23 12-09-03](https://github.com/user-attachments/assets/e8fbdea1-41b1-4d00-b267-c382caf13072)
![Screenshot from 2025-06-23 12-09-31](https://github.com/user-attachments/assets/b1a33b10-7c8e-455c-8d37-750f15ad7587)

