### PR TITLE
[Fil 1351] rkhportal add method to add dc not set issue on metaalocator refreshes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@radix-ui/react-slot": "^1.1.0",
         "@radix-ui/react-tabs": "^1.1.0",
         "@radix-ui/react-toast": "^1.2.1",
+        "@radix-ui/react-toggle-group": "^1.1.11",
         "@radix-ui/react-tooltip": "^1.1.2",
         "@safe-global/api-kit": "^2.5.6",
         "@safe-global/protocol-kit": "^5.1.1",
@@ -5741,6 +5742,60 @@
         "@radix-ui/react-use-controllable-state": "1.2.2",
         "@radix-ui/react-use-layout-effect": "1.1.1",
         "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz",
+      "integrity": "sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle-group": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.11.tgz",
+      "integrity": "sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-toggle": "1.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-tabs": "^1.1.0",
     "@radix-ui/react-toast": "^1.2.1",
+    "@radix-ui/react-toggle-group": "^1.1.11",
     "@radix-ui/react-tooltip": "^1.1.2",
     "@safe-global/api-kit": "^2.5.6",
     "@safe-global/protocol-kit": "^5.1.1",

--- a/src/components/dashboard/refreshes/RefreshesPanel.test.tsx
+++ b/src/components/dashboard/refreshes/RefreshesPanel.test.tsx
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   mockUseStateWaitMsg: vi.fn(),
   mockUseProposeRKHTransaction: vi.fn(),
   mockUseGovernanceReview: vi.fn(),
+  mockUseGetVerifierDataCap: vi.fn(),
 }));
 
 vi.mock('@/hooks/useAccount', () => ({
@@ -31,6 +32,11 @@ vi.mock('@/hooks', () => ({
   useGovernanceReview: mocks.mockUseGovernanceReview.mockReturnValue({
     mutateAsync: vi.fn(),
     reset: vi.fn(),
+  }),
+  useGetVerifierDataCap: mocks.mockUseGetVerifierDataCap.mockReturnValue({
+    data: null,
+    isLoading: false,
+    error: null,
   }),
 }));
 

--- a/src/components/dashboard/refreshes/refresh-table-actions.test.tsx
+++ b/src/components/dashboard/refreshes/refresh-table-actions.test.tsx
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   mockUseMetaAllocatorTransaction: vi.fn(),
   mockUseGovernanceReview: vi.fn(),
   mockUseMetaAllocatorReject: vi.fn(),
+  mockUseGetVerifierDataCap: vi.fn(),
 }));
 
 vi.mock('@/hooks', () => ({
@@ -42,12 +43,18 @@ vi.mock('@/hooks', () => ({
     mutateAsync: vi.fn(),
     reset: vi.fn(),
   }),
+  useGetVerifierDataCap: mocks.mockUseGetVerifierDataCap.mockReturnValue({
+    data: null,
+    isLoading: false,
+    error: null,
+  }),
 }));
 
 describe('RefreshTableActions', () => {
   const createMockRow = (refresh: Partial<Refresh>): Row<Refresh> =>
     ({
       original: {
+        actorId: 100,
         githubIssueId: 1,
         title: 'Test Refresh',
         creator: { userId: 1, name: 'Test User' },

--- a/src/components/dashboard/refreshes/refresh-table-actions.tsx
+++ b/src/components/dashboard/refreshes/refresh-table-actions.tsx
@@ -31,6 +31,7 @@ export const RefreshTableActions = ({ row }: { row: Row<Refresh> }) => {
         <RkhSignTransactionButton
           dataCap={row.original.dataCap}
           address={row.original.msigAddress}
+          actorId={row.original.actorId}
         />
       );
 

--- a/src/components/refresh/RkhSignTransactionButton.test.tsx
+++ b/src/components/refresh/RkhSignTransactionButton.test.tsx
@@ -6,10 +6,12 @@ import { createWrapper } from '@/test-utils';
 
 const mocks = vi.hoisted(() => ({
   mockUseAccount: vi.fn(),
+  mockUseGetVerifierDataCap: vi.fn(),
 }));
 
 vi.mock('@/hooks/useAccount', () => ({
   useAccount: mocks.mockUseAccount,
+  useGetVerifierDataCap: mocks.mockUseGetVerifierDataCap,
 }));
 
 describe('RkhSignTransactionButton', () => {
@@ -17,6 +19,7 @@ describe('RkhSignTransactionButton', () => {
   const defaultProps = {
     address: 'f1abc',
     dataCap: 1024,
+    actorId: 'f1abc',
   };
 
   beforeEach(() => {
@@ -24,6 +27,12 @@ describe('RkhSignTransactionButton', () => {
 
     mocks.mockUseAccount.mockReturnValue({
       account: null,
+    });
+
+    mocks.mockUseGetVerifierDataCap.mockReturnValue({
+      data: {
+        datacap: 50,
+      },
     });
   });
 

--- a/src/components/refresh/RkhSignTransactionButton.tsx
+++ b/src/components/refresh/RkhSignTransactionButton.tsx
@@ -8,7 +8,11 @@ interface RkhSignTransactionButtonProps {
   dataCap: number;
 }
 
-export function RkhSignTransactionButton({ address, actorId, dataCap }: RkhSignTransactionButtonProps) {
+export function RkhSignTransactionButton({
+  address,
+  actorId,
+  dataCap,
+}: RkhSignTransactionButtonProps) {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
   return (

--- a/src/components/refresh/RkhSignTransactionButton.tsx
+++ b/src/components/refresh/RkhSignTransactionButton.tsx
@@ -4,10 +4,11 @@ import RkhSignTransactionDialog from '@/components/refresh/dialogs/RkhSignTransa
 
 interface RkhSignTransactionButtonProps {
   address: string;
+  actorId: string;
   dataCap: number;
 }
 
-export function RkhSignTransactionButton({ address, dataCap }: RkhSignTransactionButtonProps) {
+export function RkhSignTransactionButton({ address, actorId, dataCap }: RkhSignTransactionButtonProps) {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
   return (
@@ -17,6 +18,7 @@ export function RkhSignTransactionButton({ address, dataCap }: RkhSignTransactio
       </Button>
       <RkhSignTransactionDialog
         address={address}
+        actorId={actorId}
         dataCap={dataCap}
         open={isDialogOpen}
         onOpenChange={setIsDialogOpen}

--- a/src/components/refresh/dialogs/MetaAllocatorSignTransactionDialog.test.tsx
+++ b/src/components/refresh/dialogs/MetaAllocatorSignTransactionDialog.test.tsx
@@ -127,11 +127,29 @@ describe('MetaAllocatorSignTransactionDialog Integration Tests', () => {
       });
     });
 
-    it('should go through complete success flow', async () => {
+    it('should go through complete success flow and addAllowance', async () => {
       const user = userEvent.setup();
       render(<MetaAllocatorSignTransactionDialog {...mockProps} />, { wrapper });
 
       await user.type(screen.getByRole('spinbutton', { name: /datacap/i }), '1000');
+      await user.click(screen.getByRole('button', { name: /approve/i }));
+
+      const successHeader = await screen.findByTestId('success-header');
+      expect(successHeader).toHaveTextContent('Success!');
+
+      const transactionIdSection = screen.getByTestId('transaction-id-section');
+      expect(transactionIdSection).toHaveTextContent('Transaction ID0xabcdef123456789');
+
+      const blockNumberSection = screen.getByTestId('block-number-section');
+      expect(blockNumberSection).toHaveTextContent('Block number123');
+    });
+
+    it('should go through complete success flow and setAllowance', async () => {
+      const user = userEvent.setup();
+      render(<MetaAllocatorSignTransactionDialog {...mockProps} />, { wrapper });
+
+      await user.type(screen.getByRole('spinbutton', { name: /datacap/i }), '1000');
+      await user.click(screen.getByRole('radio', {name: /set/i}));
       await user.click(screen.getByRole('button', { name: /approve/i }));
 
       const successHeader = await screen.findByTestId('success-header');

--- a/src/components/refresh/dialogs/MetaAllocatorSignTransactionDialog.test.tsx
+++ b/src/components/refresh/dialogs/MetaAllocatorSignTransactionDialog.test.tsx
@@ -149,7 +149,7 @@ describe('MetaAllocatorSignTransactionDialog Integration Tests', () => {
       render(<MetaAllocatorSignTransactionDialog {...mockProps} />, { wrapper });
 
       await user.type(screen.getByRole('spinbutton', { name: /datacap/i }), '1000');
-      await user.click(screen.getByRole('radio', {name: /set/i}));
+      await user.click(screen.getByRole('radio', { name: /set/i }));
       await user.click(screen.getByRole('button', { name: /approve/i }));
 
       const successHeader = await screen.findByTestId('success-header');
@@ -425,7 +425,7 @@ describe('MetaAllocatorSignTransactionDialog Integration Tests', () => {
       expect(screen.queryByTestId('error-message')).not.toBeInTheDocument();
     });
 
-    it('should call onSubmit with correct parameters', async () => {
+    it('should call onSubmit with correct parameters for addAllowance', async () => {
       const user = userEvent.setup();
       render(<MetaAllocatorSignTransactionDialog {...mockProps} />, { wrapper });
 
@@ -436,6 +436,23 @@ describe('MetaAllocatorSignTransactionDialog Integration Tests', () => {
         expect(mocks.mockEncodeFunctionData).toHaveBeenCalledWith({
           abi: expect.any(Array),
           functionName: 'addAllowance',
+          args: [mockProps.address, BigInt(1000 * 1_125_899_906_842_624)],
+        });
+      });
+    });
+
+    it('should call onSubmit with correct parameters for setAllowance', async () => {
+      const user = userEvent.setup();
+      render(<MetaAllocatorSignTransactionDialog {...mockProps} />, { wrapper });
+
+      await user.type(screen.getByRole('spinbutton', { name: /datacap/i }), '1000');
+      await user.click(screen.getByRole('radio', { name: /set/i }));
+      await user.click(screen.getByRole('button', { name: /approve/i }));
+
+      await waitFor(() => {
+        expect(mocks.mockEncodeFunctionData).toHaveBeenCalledWith({
+          abi: expect.any(Array),
+          functionName: 'setAllowance',
           args: [mockProps.address, BigInt(1000 * 1_125_899_906_842_624)],
         });
       });

--- a/src/components/refresh/dialogs/MetaAllocatorSignTransactionDialog.tsx
+++ b/src/components/refresh/dialogs/MetaAllocatorSignTransactionDialog.tsx
@@ -104,7 +104,7 @@ const MetaAllocatorSignTransactionDialog = ({
   });
 
   const onMetaAllocatorSubmit = useCallback(
-    async ({ dataCap }: ChangeDatacapFormValues) => {
+    async ({ dataCap, method }: ChangeDatacapFormValues) => {
       if (Number(dataCap) === 0) {
         setStep(MetaAllocatorSignSteps.REJECTION_CONFIRMATION);
       } else {
@@ -112,6 +112,7 @@ const MetaAllocatorSignTransactionDialog = ({
           address,
           datacap: dataCap,
           metaAllocatorContractAddress: maAddress,
+          method,
         });
       }
     },

--- a/src/components/refresh/dialogs/MetaAllocatorSignTransactionDialog.tsx
+++ b/src/components/refresh/dialogs/MetaAllocatorSignTransactionDialog.tsx
@@ -12,12 +12,12 @@ import {
   DialogSuccessCard,
 } from '@/components/ui/dialog';
 import { useCallback, useEffect, useState } from 'react';
-import { RefreshAllocatorSuccessStep, SetDatacapFormStep } from '@/components/refresh/steps';
+import { RefreshAllocatorSuccessStep, ChangeDatacapFormStep } from '@/components/refresh/steps';
 import { MetaAllocatorSignSteps } from '@/components/refresh/steps/constants';
 import { useMetaAllocatorTransaction, useMetaAllocatorReject } from '@/hooks';
 import { MetapathwayType } from '@/types/refresh';
 import { withFormProvider } from '@/lib/hocs/withFormProvider';
-import { SetDatacapFormValues } from '@/components/refresh/steps/SetDatacapFormStep';
+import { ChangeDatacapFormValues } from '@/components/refresh/steps/ChangeDatacapFormStep';
 import { SignatureType } from '@/types/governance-review';
 import { toast } from '@/components/ui/use-toast';
 
@@ -104,7 +104,7 @@ const MetaAllocatorSignTransactionDialog = ({
   });
 
   const onMetaAllocatorSubmit = useCallback(
-    async ({ dataCap }: SetDatacapFormValues) => {
+    async ({ dataCap }: ChangeDatacapFormValues) => {
       if (Number(dataCap) === 0) {
         setStep(MetaAllocatorSignSteps.REJECTION_CONFIRMATION);
       } else {
@@ -145,7 +145,7 @@ const MetaAllocatorSignTransactionDialog = ({
 
   const stepsConfig = {
     [MetaAllocatorSignSteps.FORM]: (
-      <SetDatacapFormStep
+      <ChangeDatacapFormStep
         rejectable
         metapathwayType={metapathwayType}
         dataCap={dataCap}

--- a/src/components/refresh/dialogs/RkhSignTransactionDialog.test.tsx
+++ b/src/components/refresh/dialogs/RkhSignTransactionDialog.test.tsx
@@ -59,6 +59,8 @@ describe('RkhSignTransactionDialog Integration Tests', () => {
     success: true,
   };
 
+  const mockDataCap = 10n ** 18n;
+
   beforeEach(() => {
     vi.clearAllMocks();
 
@@ -71,7 +73,7 @@ describe('RkhSignTransactionDialog Integration Tests', () => {
     });
 
     mocks.mockUseGetVerifierDataCap.mockReturnValue({
-      data: { datacap: 1000 },
+      data: { datacap: mockDataCap, verifier: 'f012345' },
       isLoading: false,
       isError: false,
       error: null,
@@ -105,7 +107,11 @@ describe('RkhSignTransactionDialog Integration Tests', () => {
       await user.type(screen.getByRole('spinbutton', { name: /datacap/i }), '1000');
       await user.click(screen.getByRole('button', { name: /approve/i }));
 
-      expect(mocks.mockProposeAddVerifier).toHaveBeenCalledWith(mockProps.address, 2000);
+      expect(mocks.mockProposeAddVerifier).toHaveBeenCalledWith(
+        mockProps.address,
+        '1000',
+        mockDataCap,
+      );
 
       const successHeader = await screen.findByTestId('success-header');
       expect(successHeader).toHaveTextContent('Success!');
@@ -125,7 +131,7 @@ describe('RkhSignTransactionDialog Integration Tests', () => {
       await user.click(screen.getByRole('radio', { name: /set/i }));
       await user.click(screen.getByRole('button', { name: /approve/i }));
 
-      expect(mocks.mockProposeAddVerifier).toHaveBeenCalledWith(mockProps.address, 1000);
+      expect(mocks.mockProposeAddVerifier).toHaveBeenCalledWith(mockProps.address, '1000');
 
       const successHeader = await screen.findByTestId('success-header');
       expect(successHeader).toHaveTextContent('Success!');

--- a/src/components/refresh/dialogs/RkhSignTransactionDialog.test.tsx
+++ b/src/components/refresh/dialogs/RkhSignTransactionDialog.test.tsx
@@ -7,6 +7,7 @@ import { ApiStateWaitMsgResponse } from '@/types/filecoin-client';
 
 const mocks = vi.hoisted(() => ({
   mockUseAccount: vi.fn(),
+  mockUseGetVerifierDataCap: vi.fn(),
   mockProposeAddVerifier: vi.fn(),
   mockGetStateWaitMsg: vi.fn(),
   mockUseToast: vi.fn(),
@@ -21,6 +22,10 @@ vi.mock('@/hooks/useAccount', () => ({
   useAccount: mocks.mockUseAccount,
 }));
 
+vi.mock('@/hooks/useGetVerifierDataCap', () => ({
+  useGetVerifierDataCap: mocks.mockUseGetVerifierDataCap,
+}));
+
 vi.mock('@/components/ui/use-toast', () => ({
   useToast: mocks.mockUseToast,
 }));
@@ -31,6 +36,7 @@ describe('RkhSignTransactionDialog Integration Tests', () => {
     open: true,
     address: 'f1234567890abcdef',
     onOpenChange: vi.fn(),
+    actorId: 'f012345',
   };
   const mockStateWaitResponse: ApiStateWaitMsgResponse = {
     data: {
@@ -63,6 +69,13 @@ describe('RkhSignTransactionDialog Integration Tests', () => {
     mocks.mockUseToast.mockReturnValue({
       toast: mocks.mockToast,
     });
+
+    mocks.mockUseGetVerifierDataCap.mockReturnValue({
+      data: { datacap: 1000 },
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
   });
 
   it('should render dialog with correct title and description', () => {
@@ -85,14 +98,34 @@ describe('RkhSignTransactionDialog Integration Tests', () => {
       mocks.mockGetStateWaitMsg.mockResolvedValue(mockStateWaitResponse);
     });
 
-    it('should go through complete success flow', async () => {
+    it('should go through complete success flow and add datacap', async () => {
       const user = userEvent.setup();
       render(<RkhSignTransactionDialog {...mockProps} />, { wrapper });
 
       await user.type(screen.getByRole('spinbutton', { name: /datacap/i }), '1000');
       await user.click(screen.getByRole('button', { name: /approve/i }));
 
-      expect(mocks.mockProposeAddVerifier).toHaveBeenCalledWith(mockProps.address, '1000');
+      expect(mocks.mockProposeAddVerifier).toHaveBeenCalledWith(mockProps.address, 2000);
+
+      const successHeader = await screen.findByTestId('success-header');
+      expect(successHeader).toHaveTextContent('Success!');
+
+      const transactionIdSection = screen.getByTestId('transaction-id-section');
+      expect(transactionIdSection).toHaveTextContent('Transaction IDmessage-id-123');
+
+      const blockNumberSection = screen.getByTestId('block-number-section');
+      expect(blockNumberSection).toHaveTextContent('Block number12345');
+    });
+
+    it('should go through complete success flow and set datacap', async () => {
+      const user = userEvent.setup();
+      render(<RkhSignTransactionDialog {...mockProps} />, { wrapper });
+
+      await user.type(screen.getByRole('spinbutton', { name: /datacap/i }), '1000');
+      await user.click(screen.getByRole('radio', {name: /set/i}));
+      await user.click(screen.getByRole('button', { name: /approve/i }));
+
+      expect(mocks.mockProposeAddVerifier).toHaveBeenCalledWith(mockProps.address, 1000);
 
       const successHeader = await screen.findByTestId('success-header');
       expect(successHeader).toHaveTextContent('Success!');

--- a/src/components/refresh/dialogs/RkhSignTransactionDialog.test.tsx
+++ b/src/components/refresh/dialogs/RkhSignTransactionDialog.test.tsx
@@ -122,7 +122,7 @@ describe('RkhSignTransactionDialog Integration Tests', () => {
       render(<RkhSignTransactionDialog {...mockProps} />, { wrapper });
 
       await user.type(screen.getByRole('spinbutton', { name: /datacap/i }), '1000');
-      await user.click(screen.getByRole('radio', {name: /set/i}));
+      await user.click(screen.getByRole('radio', { name: /set/i }));
       await user.click(screen.getByRole('button', { name: /approve/i }));
 
       expect(mocks.mockProposeAddVerifier).toHaveBeenCalledWith(mockProps.address, 1000);

--- a/src/components/refresh/dialogs/RkhSignTransactionDialog.tsx
+++ b/src/components/refresh/dialogs/RkhSignTransactionDialog.tsx
@@ -12,14 +12,13 @@ import {
 import { useCallback, useEffect, useState } from 'react';
 import { RefreshAllocatorSuccessStep } from '@/components/refresh/steps';
 import { RefreshAllocatorSteps } from '@/components/refresh/steps/constants';
-import { useProposeRKHTransaction, useStateWaitMsg } from '@/hooks';
+import { useProposeRKHTransaction, useStateWaitMsg, useGetVerifierDataCap } from '@/hooks';
 import { MetapathwayType } from '@/types/refresh';
 import {
   ChangeDatacapFormStep,
   ChangeDatacapFormValues,
 } from '@/components/refresh/steps/ChangeDatacapFormStep';
 import { withFormProvider } from '@/lib/hocs/withFormProvider';
-import { useGetVerifierDataCap } from '@/hooks/useGetVerifierDataCap';
 
 interface RkhSignTransactionDialogProps {
   open: boolean;
@@ -71,7 +70,7 @@ const RkhSignTransactionDialog = ({
 
   const onSubmit = useCallback(
     async ({ dataCap, method }: ChangeDatacapFormValues) => {
-      const datacapForSubmit = method === 'add' ? dataCap + (verifierData?.datacap || 0) : dataCap;
+      const datacapForSubmit = method === 'add' ? Number(dataCap) + Number(verifierData?.datacap || 0) : Number(dataCap);
       proposeTransaction({ address, datacap: datacapForSubmit }).catch(error => {
         console.error('Error proposing verifier:', error);
       })

--- a/src/components/refresh/dialogs/RkhSignTransactionDialog.tsx
+++ b/src/components/refresh/dialogs/RkhSignTransactionDialog.tsx
@@ -15,15 +15,17 @@ import { RefreshAllocatorSteps } from '@/components/refresh/steps/constants';
 import { useProposeRKHTransaction, useStateWaitMsg } from '@/hooks';
 import { MetapathwayType } from '@/types/refresh';
 import {
-  SetDatacapFormStep,
-  SetDatacapFormValues,
-} from '@/components/refresh/steps/SetDatacapFormStep';
+  ChangeDatacapFormStep,
+  ChangeDatacapFormValues,
+} from '@/components/refresh/steps/ChangeDatacapFormStep';
 import { withFormProvider } from '@/lib/hocs/withFormProvider';
+import { useGetVerifierDataCap } from '@/hooks/useGetVerifierDataCap';
 
 interface RkhSignTransactionDialogProps {
   open: boolean;
   address: string;
   dataCap?: number;
+  actorId: string;
   onOpenChange: (open: boolean) => void;
 }
 
@@ -32,6 +34,7 @@ const RkhSignTransactionDialog = ({
   open,
   address,
   dataCap,
+  actorId,
 }: RkhSignTransactionDialogProps) => {
   const [step, setStep] = useState(RefreshAllocatorSteps.FORM);
   const [loadingMessage, setLoadingMessage] = useState<string | null>(null);
@@ -62,12 +65,18 @@ const RkhSignTransactionDialog = ({
     onProposeTransactionSuccess: (messageId: string) => checkTransactionState(messageId),
   });
 
+  const { data: verifierData } = useGetVerifierDataCap(actorId, {
+    enabled: !!actorId && open,
+  });
+
   const onSubmit = useCallback(
-    async ({ dataCap }: SetDatacapFormValues) =>
-      proposeTransaction({ address, datacap: dataCap }).catch(error => {
+    async ({ dataCap, method }: ChangeDatacapFormValues) => {
+      const datacapForSubmit = method === 'add' ? dataCap + (verifierData?.datacap || 0) : dataCap;
+      proposeTransaction({ address, datacap: datacapForSubmit }).catch(error => {
         console.error('Error proposing verifier:', error);
-      }),
-    [address, proposeTransaction],
+      })
+    },
+    [address, proposeTransaction, verifierData?.datacap],
   );
 
   const getBlockNumber = () => {
@@ -76,8 +85,9 @@ const RkhSignTransactionDialog = ({
 
   const stepsConfig = {
     [RefreshAllocatorSteps.FORM]: (
-      <SetDatacapFormStep
+      <ChangeDatacapFormStep
         metapathwayType={MetapathwayType.RKH}
+        verifierDataCap={verifierData?.datacap || 0}
         dataCap={dataCap}
         toAddress={address}
         onSubmit={onSubmit}

--- a/src/components/refresh/dialogs/RkhSignTransactionDialog.tsx
+++ b/src/components/refresh/dialogs/RkhSignTransactionDialog.tsx
@@ -9,7 +9,7 @@ import {
   DialogLoadingCard,
   DialogTitle,
 } from '@/components/ui/dialog';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { RefreshAllocatorSuccessStep } from '@/components/refresh/steps';
 import { RefreshAllocatorSteps } from '@/components/refresh/steps/constants';
 import { useProposeRKHTransaction, useStateWaitMsg, useGetVerifierDataCap } from '@/hooks';
@@ -68,15 +68,34 @@ const RkhSignTransactionDialog = ({
     enabled: !!actorId && open,
   });
 
+  const datacapInPib = useMemo(() => {
+    if (!verifierData?.datacap) return '0';
+    return (Number(verifierData?.datacap) / 1_125_899_906_842_624).toFixed(2);
+  }, [verifierData?.datacap]);
+
   const onSubmit = useCallback(
     async ({ dataCap, method }: ChangeDatacapFormValues) => {
-      const datacapForSubmit =
-        method === 'add' ? Number(dataCap) + Number(verifierData?.datacap || 0) : Number(dataCap);
-      proposeTransaction({ address, datacap: datacapForSubmit }).catch(error => {
-        console.error('Error proposing verifier:', error);
-      });
+      if (method === 'add') {
+        if (verifierData === undefined) {
+          setStep(RefreshAllocatorSteps.ERROR);
+          setErrorMessage('Verifier data not found');
+          return;
+        }
+
+        proposeTransaction({
+          address,
+          datacap: dataCap,
+          additionalDataCap: verifierData?.datacap,
+        }).catch(error => {
+          console.error('Error proposing verifier:', error);
+        });
+      } else {
+        proposeTransaction({ address, datacap: dataCap }).catch(error => {
+          console.error('Error proposing verifier:', error);
+        });
+      }
     },
-    [address, proposeTransaction, verifierData?.datacap],
+    [address, proposeTransaction, verifierData],
   );
 
   const getBlockNumber = () => {
@@ -87,7 +106,7 @@ const RkhSignTransactionDialog = ({
     [RefreshAllocatorSteps.FORM]: (
       <ChangeDatacapFormStep
         metapathwayType={MetapathwayType.RKH}
-        verifierDataCap={verifierData?.datacap || 0}
+        verifierDataCap={datacapInPib}
         dataCap={dataCap}
         toAddress={address}
         onSubmit={onSubmit}

--- a/src/components/refresh/dialogs/RkhSignTransactionDialog.tsx
+++ b/src/components/refresh/dialogs/RkhSignTransactionDialog.tsx
@@ -70,10 +70,11 @@ const RkhSignTransactionDialog = ({
 
   const onSubmit = useCallback(
     async ({ dataCap, method }: ChangeDatacapFormValues) => {
-      const datacapForSubmit = method === 'add' ? Number(dataCap) + Number(verifierData?.datacap || 0) : Number(dataCap);
+      const datacapForSubmit =
+        method === 'add' ? Number(dataCap) + Number(verifierData?.datacap || 0) : Number(dataCap);
       proposeTransaction({ address, datacap: datacapForSubmit }).catch(error => {
         console.error('Error proposing verifier:', error);
-      })
+      });
     },
     [address, proposeTransaction, verifierData?.datacap],
   );

--- a/src/components/refresh/steps/ChangeDatacapFormStep.tsx
+++ b/src/components/refresh/steps/ChangeDatacapFormStep.tsx
@@ -62,12 +62,20 @@ export const ChangeDatacapFormStep = ({
           <MetapathwayTypeBadge metapathwayType={metapathwayType} />
         </div>
 
-        {verifierDataCap ? <div data-testid="allocator-type" className="flex flex-row justify-between mb-2">
-          <Label>Allocator Datacap:</Label>
-          <span>{verifierDataCap} PiB</span>
-        </div> : null}
+        {verifierDataCap ? (
+          <div data-testid="allocator-type" className="flex flex-row justify-between mb-2">
+            <Label>Allocator Datacap:</Label>
+            <span>{verifierDataCap} PiB</span>
+          </div>
+        ) : null}
 
-        <ControlledFormItem className="w-full" name="method" defaultValue="add" label="Method" control={control}>
+        <ControlledFormItem
+          className="w-full"
+          name="method"
+          defaultValue="add"
+          label="Method"
+          control={control}
+        >
           <Switcher className="w-full" options={methodOptions} />
         </ControlledFormItem>
 

--- a/src/components/refresh/steps/ChangeDatacapFormStep.tsx
+++ b/src/components/refresh/steps/ChangeDatacapFormStep.tsx
@@ -1,5 +1,5 @@
 import { useFormContext, useWatch } from 'react-hook-form';
-import { useMemo } from 'react';
+import { useMemo, useEffect } from 'react';
 
 import { ControlledFormItem } from '@/components/ui/form-item';
 import { Input } from '@/components/ui/input';
@@ -67,8 +67,8 @@ export const ChangeDatacapFormStep = ({
           <span>{verifierDataCap} PiB</span>
         </div> : null}
 
-        <ControlledFormItem className="w-full" name="method" label="Method" control={control}>
-          <Switcher className="w-full" defaultValue="add" options={methodOptions} />
+        <ControlledFormItem className="w-full" name="method" defaultValue="add" label="Method" control={control}>
+          <Switcher className="w-full" options={methodOptions} />
         </ControlledFormItem>
 
         <ControlledFormItem

--- a/src/components/refresh/steps/ChangeDatacapFormStep.tsx
+++ b/src/components/refresh/steps/ChangeDatacapFormStep.tsx
@@ -19,7 +19,7 @@ export interface ChangeDatacapFormValues {
 interface ChangeDatacapFormStepProps {
   rejectable?: boolean;
   metapathwayType: MetapathwayType;
-  verifierDataCap?: number;
+  verifierDataCap?: string;
   dataCap?: number;
   toAddress?: string;
   onSubmit: (data: ChangeDatacapFormValues) => void;

--- a/src/components/refresh/steps/ChangeDatacapFormStep.tsx
+++ b/src/components/refresh/steps/ChangeDatacapFormStep.tsx
@@ -1,4 +1,5 @@
 import { useFormContext, useWatch } from 'react-hook-form';
+import { useMemo } from 'react';
 
 import { ControlledFormItem } from '@/components/ui/form-item';
 import { Input } from '@/components/ui/input';
@@ -8,31 +9,41 @@ import { validationRules } from '@/components/refresh/dialogs/RefreshAllocatorVa
 import { Label } from '@/components/ui/label';
 import { MetapathwayTypeBadge } from '@/components/dashboard/components/MetapathwayTypeBadge';
 import { RejectableFormLegend } from './components/RejectableFormLegend';
+import { Switcher } from '@/components/ui/switcher';
 
-export interface SetDatacapFormValues {
+export interface ChangeDatacapFormValues {
   dataCap: number;
+  method: 'add' | 'set';
 }
 
-interface SetDatacapFormStepProps {
+interface ChangeDatacapFormStepProps {
   rejectable?: boolean;
   metapathwayType: MetapathwayType;
+  verifierDataCap?: number;
   dataCap?: number;
   toAddress?: string;
-  onSubmit: (data: SetDatacapFormValues) => void;
+  onSubmit: (data: ChangeDatacapFormValues) => void;
   onCancel: () => void;
 }
 
-export const SetDatacapFormStep = ({
+export const ChangeDatacapFormStep = ({
   rejectable,
   metapathwayType,
+  verifierDataCap,
   dataCap,
   toAddress,
   onSubmit,
   onCancel,
-}: SetDatacapFormStepProps) => {
-  const { control, handleSubmit } = useFormContext<SetDatacapFormValues>();
+}: ChangeDatacapFormStepProps) => {
+  const { control, handleSubmit } = useFormContext<ChangeDatacapFormValues>();
   const dataCapValidationRules = validationRules.dataCap();
   const datacap = useWatch({ name: 'dataCap' });
+  const methodOptions = useMemo(() => {
+    return [
+      { label: 'Add', value: 'add' },
+      { label: 'Set', value: 'set' },
+    ];
+  }, []);
 
   return (
     <form role="form" className="flex flex-col px-4 gap-4" onSubmit={handleSubmit(onSubmit)}>
@@ -45,10 +56,20 @@ export const SetDatacapFormStep = ({
             <span className="text-muted-foreground break-all">{toAddress}</span>
           </div>
         ) : null}
-        <div data-testid="allocator-type" className="flex flex-row justify-between">
+
+        <div data-testid="allocator-type" className="flex flex-row justify-between mb-2">
           <Label>Allocator Type:</Label>
           <MetapathwayTypeBadge metapathwayType={metapathwayType} />
         </div>
+
+        {verifierDataCap ? <div data-testid="allocator-type" className="flex flex-row justify-between mb-2">
+          <Label>Allocator Datacap:</Label>
+          <span>{verifierDataCap} PiB</span>
+        </div> : null}
+
+        <ControlledFormItem className="w-full" name="method" label="Method" control={control}>
+          <Switcher className="w-full" defaultValue="add" options={methodOptions} />
+        </ControlledFormItem>
 
         <ControlledFormItem
           className="w-full"

--- a/src/components/refresh/steps/SetDatacapFormStep.test.tsx
+++ b/src/components/refresh/steps/SetDatacapFormStep.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { FormProvider, useForm } from 'react-hook-form';
 import { WrapperBuilder } from '@/test-utils/wrapper-builder';
 import { createWrapper } from '@/test-utils';
-import { SetDatacapFormStep, type SetDatacapFormValues } from './SetDatacapFormStep';
+import { ChangeDatacapFormStep, type ChangeDatacapFormValues } from './ChangeDatacapFormStep';
 import { MetapathwayType, type Refresh, RefreshStatus } from '@/types/refresh';
 
 describe('SetDatacapFormStep', () => {
@@ -12,7 +12,7 @@ describe('SetDatacapFormStep', () => {
   const fixtureMetapathwayType = MetapathwayType.RKH;
 
   const TestFormProvider = ({ children }: { children: React.ReactNode }) => {
-    const methods = useForm<SetDatacapFormValues>({
+    const methods = useForm<ChangeDatacapFormValues>({
       defaultValues: {
         dataCap: fixtureDataCap,
       },
@@ -31,7 +31,7 @@ describe('SetDatacapFormStep', () => {
 
   it('renders allocator type, datacap input and action buttons', () => {
     render(
-      <SetDatacapFormStep
+      <ChangeDatacapFormStep
         metapathwayType={fixtureMetapathwayType}
         dataCap={fixtureDataCap}
         onSubmit={onSubmit}
@@ -51,7 +51,7 @@ describe('SetDatacapFormStep', () => {
 
   it('pre-fills datacap with refresh value', () => {
     render(
-      <SetDatacapFormStep
+      <ChangeDatacapFormStep
         metapathwayType={fixtureMetapathwayType}
         dataCap={fixtureDataCap}
         onSubmit={onSubmit}
@@ -70,7 +70,7 @@ describe('SetDatacapFormStep', () => {
     const user = userEvent.setup();
 
     render(
-      <SetDatacapFormStep
+      <ChangeDatacapFormStep
         metapathwayType={fixtureMetapathwayType}
         dataCap={fixtureDataCap}
         onSubmit={onSubmit}
@@ -91,7 +91,7 @@ describe('SetDatacapFormStep', () => {
     const user = userEvent.setup();
 
     render(
-      <SetDatacapFormStep
+      <ChangeDatacapFormStep
         metapathwayType={fixtureMetapathwayType}
         dataCap={fixtureDataCap}
         onSubmit={onSubmit}

--- a/src/components/refresh/steps/index.ts
+++ b/src/components/refresh/steps/index.ts
@@ -1,4 +1,4 @@
 export * from './ApproveTransactionDetailsStep';
 export * from './RefreshAllocatorFormStep';
 export * from './RefreshAllocatorSuccessStep';
-export * from './SetDatacapFormStep';
+export * from './ChangeDatacapFormStep';

--- a/src/components/ui/switcher.tsx
+++ b/src/components/ui/switcher.tsx
@@ -49,7 +49,7 @@ const Switcher = React.forwardRef<HTMLDivElement, SwitcherProps>(
         id={id}
         value={value}
         onValueChange={val => {
-          if (val) onChange?.(val as never);
+          if (val) onChange?.(val);
         }}
         onBlur={onBlur}
         disabled={disabled}

--- a/src/components/ui/switcher.tsx
+++ b/src/components/ui/switcher.tsx
@@ -1,0 +1,83 @@
+import * as ToggleGroup from '@radix-ui/react-toggle-group';
+import * as React from 'react';
+import { cva } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+const SwitcherRoot = ToggleGroup.Root;
+const SwitcherItem = ToggleGroup.Item;
+
+const switcherRootVariants = cva('flex rounded-md border', {
+  variants: {
+    error: {
+      true: 'border-red-500',
+      false: 'border-gray-200',
+    },
+    disabled: {
+      true: 'opacity-50 cursor-not-allowed',
+      false: '',
+    },
+  },
+  defaultVariants: {
+    error: false,
+    disabled: false,
+  },
+});
+
+type SwitcherOption<T extends string = string> = {
+  label: string;
+  value: T;
+};
+
+type SwitcherProps<T extends string = string> = {
+  options: SwitcherOption<T>[];
+  value?: T;
+  defaultValue?: T;
+  onChange?: (value: T) => void;
+  onBlur?: () => void;
+  disabled?: boolean;
+  error?: boolean;
+  id?: string;
+  className?: string;
+};
+
+const Switcher = React.forwardRef<HTMLDivElement, SwitcherProps>(
+  ({ options, value, defaultValue, onChange, onBlur, disabled, error, id, className }, ref) => {
+    return (
+      <SwitcherRoot
+        ref={ref}
+        type="single"
+        id={id}
+        value={value}
+        onValueChange={val => {
+          if (val) onChange?.(val as never);
+        }}
+        onBlur={onBlur}
+        disabled={disabled}
+        defaultValue={defaultValue}
+        className={cn(switcherRootVariants({ error, disabled }), className)}
+      >
+        {options.map(option => (
+          <SwitcherItem
+            key={option.value}
+            value={option.value}
+            className={cn(
+              'flex-1 flex items-center justify-center',
+              'px-4 py-2 text-sm font-medium transition-colors',
+              'first:rounded-l-md last:rounded-r-md',
+              'data-[state=on]:bg-primary data-[state=on]:text-white',
+              'data-[state=off]:bg-white data-[state=off]:text-gray-600',
+              'hover:bg-gray-50 data-[state=on]:hover:bg-primary/90',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary',
+            )}
+          >
+            {option.label}
+          </SwitcherItem>
+        ))}
+      </SwitcherRoot>
+    );
+  },
+);
+
+Switcher.displayName = 'Switcher';
+
+export { Switcher };

--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -43,7 +43,7 @@ const environments: { [key: string]: Environment } = {
     rpcUrl: 'http://localhost:3001/api/v1/rpc',
     metaAllocatorContractAddress: '0xB6F5d279AEad97dFA45209F3E53969c2EF43C21d',
     githubOwner: 'filecoin-project',
-    safeAddress: '0x2e25A2f6bC2C0b7669DFB25180Ed57e07dAabe9e',
+    safeAddress: '0x7bba994c3492f60437b3c5ff0d5ca36c3060f9ad',
   },
   staging: {
     apiBaseUrl: 'https://allocator-rkh-testenv-8dphx.ondigitalocean.app/backend/api/v1',

--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -43,7 +43,7 @@ const environments: { [key: string]: Environment } = {
     rpcUrl: 'http://localhost:3001/api/v1/rpc',
     metaAllocatorContractAddress: '0xB6F5d279AEad97dFA45209F3E53969c2EF43C21d',
     githubOwner: 'filecoin-project',
-    safeAddress: '0xa6d01c6e053170cff6de826116949d0a315aae80',
+    safeAddress: '0x2e25A2f6bC2C0b7669DFB25180Ed57e07dAabe9e',
   },
   staging: {
     apiBaseUrl: 'https://allocator-rkh-testenv-8dphx.ondigitalocean.app/backend/api/v1',

--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -43,7 +43,7 @@ const environments: { [key: string]: Environment } = {
     rpcUrl: 'http://localhost:3001/api/v1/rpc',
     metaAllocatorContractAddress: '0xB6F5d279AEad97dFA45209F3E53969c2EF43C21d',
     githubOwner: 'filecoin-project',
-    safeAddress: '0x7bba994c3492f60437b3c5ff0d5ca36c3060f9ad',
+    safeAddress: '0xa6d01c6e053170cff6de826116949d0a315aae80',
   },
   staging: {
     apiBaseUrl: 'https://allocator-rkh-testenv-8dphx.ondigitalocean.app/backend/api/v1',

--- a/src/contexts/AccountContext.ts
+++ b/src/contexts/AccountContext.ts
@@ -16,7 +16,11 @@ export interface AccountContextType {
   signStateMessage: (message: string) => Promise<string>;
 
   // Root Key Holder
-  proposeAddVerifier: (verifierAddress: string, datacap: number) => Promise<string>;
+  proposeAddVerifier: (
+    verifierAddress: string,
+    datacap: number,
+    additionalDataCap?: bigint,
+  ) => Promise<string>;
   acceptVerifierProposal: (
     verifierAddress: string,
     datacap: number,
@@ -25,7 +29,7 @@ export interface AccountContextType {
   ) => Promise<string>;
 
   // Verifier
-  checkActorDataCap: (actorId: string) => Promise<{ datacap: number; verifier: string }>;
+  checkActorDataCap: (actorId: string) => Promise<{ datacap: bigint; verifier: string }>;
 }
 
 export const AccountContext = createContext<AccountContextType | undefined>(undefined);

--- a/src/contexts/AccountContext.ts
+++ b/src/contexts/AccountContext.ts
@@ -23,6 +23,9 @@ export interface AccountContextType {
     fromAccount: string,
     transactionId: number,
   ) => Promise<string>;
+
+  // Verifier
+  checkActorDataCap: (actorId: string) => Promise<{ datacap: number; verifier: string }>;
 }
 
 export const AccountContext = createContext<AccountContextType | undefined>(undefined);

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -16,3 +16,4 @@ export * from './useProposalActions';
 export * from './useMaAddresses';
 export * from './useGovernanceReview';
 export * from './useMetaAllocatorReject';
+export * from './useGetVerifierDataCap';

--- a/src/hooks/useGetVerifierDataCap.test.ts
+++ b/src/hooks/useGetVerifierDataCap.test.ts
@@ -1,0 +1,136 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { createElement, type ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AccountContext, type AccountContextType } from '@/contexts/AccountContext';
+import { useGetVerifierDataCap } from './useGetVerifierDataCap';
+
+const mockCheckActorDataCap = vi.fn();
+
+const mockAccountContext: AccountContextType = {
+  account: null,
+  selectedMetaAllocator: null,
+  connectors: {},
+  connect: vi.fn(),
+  disconnect: vi.fn(),
+  loadPersistedAccount: vi.fn(),
+  signStateMessage: vi.fn(),
+  proposeAddVerifier: vi.fn(),
+  acceptVerifierProposal: vi.fn(),
+  checkActorDataCap: mockCheckActorDataCap,
+};
+
+function createTestWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  return ({ children }: { children: ReactNode }) =>
+    createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      createElement(AccountContext.Provider, { value: mockAccountContext }, children),
+    );
+}
+
+describe('useGetVerifierDataCap', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should fetch datacap for a given actorId', async () => {
+    const mockData = { datacap: 1000, verifier: 'f01234' };
+    mockCheckActorDataCap.mockResolvedValue(mockData);
+
+    const wrapper = createTestWrapper();
+    const { result } = renderHook(() => useGetVerifierDataCap('f01234'), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual(mockData);
+    expect(mockCheckActorDataCap).toHaveBeenCalledWith('f01234');
+  });
+
+  it('should not fetch when actorId is empty', () => {
+    const wrapper = createTestWrapper();
+    const { result } = renderHook(() => useGetVerifierDataCap(''), {
+      wrapper,
+    });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockCheckActorDataCap).not.toHaveBeenCalled();
+  });
+
+  it('should handle API errors', async () => {
+    const apiError = new Error('Failed to fetch datacap');
+    mockCheckActorDataCap.mockRejectedValue(apiError);
+
+    const wrapper = createTestWrapper();
+    const { result } = renderHook(() => useGetVerifierDataCap('f09999'), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error).toEqual(apiError);
+  });
+
+  it('should use the correct query key', async () => {
+    mockCheckActorDataCap.mockResolvedValue({ datacap: 500, verifier: 'f05678' });
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        createElement(AccountContext.Provider, { value: mockAccountContext }, children),
+      );
+
+    renderHook(() => useGetVerifierDataCap('f05678'), { wrapper });
+
+    await waitFor(() => {
+      const queryState = queryClient.getQueryState(['checkActorDataCap', 'f05678']);
+      expect(queryState).toBeDefined();
+    });
+  });
+
+  it('should throw when used outside AccountProvider', () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children);
+
+    expect(() => {
+      renderHook(() => useGetVerifierDataCap('f01234'), { wrapper });
+    }).toThrow('useAccountRole must be used within an AccountProvider');
+  });
+
+  it('should pass additional query options via params', async () => {
+    mockCheckActorDataCap.mockResolvedValue({ datacap: 200, verifier: 'f03333' });
+
+    const wrapper = createTestWrapper();
+    const { result } = renderHook(
+      () =>
+        useGetVerifierDataCap('f03333', {
+          enabled: false,
+        }),
+      { wrapper },
+    );
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockCheckActorDataCap).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useGetVerifierDataCap.ts
+++ b/src/hooks/useGetVerifierDataCap.ts
@@ -1,0 +1,23 @@
+import { useContext } from 'react';
+import { AccountContext } from '@/contexts/AccountContext';
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+
+/**
+ * Custom hook to access the account role.
+ * @returns Account role.
+ */
+type VerifierDataCap = { datacap: number; verifier: string };
+
+export function useGetVerifierDataCap(actorId: string, params?: Partial<UseQueryOptions<VerifierDataCap, Error, VerifierDataCap>>) {
+  const context = useContext(AccountContext);
+  if (!context) {
+    throw new Error('useAccountRole must be used within an AccountProvider');
+  }
+
+  return useQuery<VerifierDataCap>({
+    queryKey: ['checkActorDataCap', actorId],
+    queryFn: () => context.checkActorDataCap(actorId),
+    enabled: !!actorId,
+    ...params,
+  });
+}

--- a/src/hooks/useGetVerifierDataCap.ts
+++ b/src/hooks/useGetVerifierDataCap.ts
@@ -8,7 +8,10 @@ import { useQuery, UseQueryOptions } from '@tanstack/react-query';
  */
 type VerifierDataCap = { datacap: number; verifier: string };
 
-export function useGetVerifierDataCap(actorId: string, params?: Partial<UseQueryOptions<VerifierDataCap, Error, VerifierDataCap>>) {
+export function useGetVerifierDataCap(
+  actorId: string,
+  params?: Partial<UseQueryOptions<VerifierDataCap, Error, VerifierDataCap>>,
+) {
   const context = useContext(AccountContext);
   if (!context) {
     throw new Error('useAccountRole must be used within an AccountProvider');

--- a/src/hooks/useGetVerifierDataCap.ts
+++ b/src/hooks/useGetVerifierDataCap.ts
@@ -2,11 +2,7 @@ import { useContext } from 'react';
 import { AccountContext } from '@/contexts/AccountContext';
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 
-/**
- * Custom hook to access the account role.
- * @returns Account role.
- */
-type VerifierDataCap = { datacap: number; verifier: string };
+type VerifierDataCap = { datacap: bigint; verifier: string };
 
 export function useGetVerifierDataCap(
   actorId: string,

--- a/src/hooks/useMetaAllocatorTransaction.test.ts
+++ b/src/hooks/useMetaAllocatorTransaction.test.ts
@@ -142,6 +142,7 @@ describe('useMetaAllocatorTransaction', () => {
       address: '0x1234567890123456789012345678901234567890',
       datacap: 100,
       metaAllocatorContractAddress: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as `0x${string}`,
+      method: 'add' as const,
     };
 
     const { result } = renderHook(
@@ -200,6 +201,7 @@ describe('useMetaAllocatorTransaction', () => {
       address: 'f1abc123def456',
       datacap: 50,
       metaAllocatorContractAddress: 'f1def456abc123' as `0x${string}`,
+      method: 'add' as const,
     };
 
     const { result } = renderHook(
@@ -243,6 +245,7 @@ describe('useMetaAllocatorTransaction', () => {
       address: 'f1abc123def456',
       datacap: 100,
       metaAllocatorContractAddress: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as `0x${string}`,
+      method: 'add' as const,
     };
 
     const { result } = renderHook(
@@ -275,6 +278,7 @@ describe('useMetaAllocatorTransaction', () => {
       address: 'f1abc123def456',
       datacap: 100,
       metaAllocatorContractAddress: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as `0x${string}`,
+      method: 'add' as const,
     };
 
     const { result } = renderHook(
@@ -305,6 +309,7 @@ describe('useMetaAllocatorTransaction', () => {
       address: 'f1abc123def456',
       datacap: 100,
       metaAllocatorContractAddress: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as `0x${string}`,
+      method: 'add' as const,
     };
 
     const { result } = renderHook(
@@ -337,6 +342,7 @@ describe('useMetaAllocatorTransaction', () => {
       address: '0x1234567890123456789012345678901234567890',
       datacap: 100,
       metaAllocatorContractAddress: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as `0x${string}`,
+      method: 'add' as const,
     };
 
     const { result } = renderHook(
@@ -367,6 +373,7 @@ describe('useMetaAllocatorTransaction', () => {
       address: '0x1234567890123456789012345678901234567890',
       datacap: 100,
       metaAllocatorContractAddress: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as `0x${string}`,
+      method: 'add' as const,
     };
 
     const { result } = renderHook(
@@ -399,6 +406,7 @@ describe('useMetaAllocatorTransaction', () => {
       address: '0x1234567890123456789012345678901234567890',
       datacap: 100,
       metaAllocatorContractAddress: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as `0x${string}`,
+      method: 'add' as const,
     };
 
     const { result } = renderHook(
@@ -428,6 +436,7 @@ describe('useMetaAllocatorTransaction', () => {
       address: '0x1234567890123456789012345678901234567890',
       datacap: 5,
       metaAllocatorContractAddress: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as `0x${string}`,
+      method: 'add' as const,
     };
 
     const { result } = renderHook(() => useMetaAllocatorTransaction({}), { wrapper });
@@ -464,6 +473,7 @@ describe('useMetaAllocatorTransaction', () => {
       address: '0x1234567890123456789012345678901234567890',
       datacap: 100,
       metaAllocatorContractAddress: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as `0x${string}`,
+      method: 'add' as const,
     };
 
     const { result } = renderHook(

--- a/src/hooks/useMetaAllocatorTransaction.ts
+++ b/src/hooks/useMetaAllocatorTransaction.ts
@@ -65,6 +65,27 @@ const addAllowanceContractAbi = [
   },
 ];
 
+const setAllowanceContractAbi = [
+  {
+    type: 'function',
+    name: 'setAllowance',
+    inputs: [
+      {
+        name: 'allocator',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: 'amount',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+];
+
 interface MetaAllocatorTransaction {
   onSubmitSafeTransaction?: () => void;
   onSubmitSafeTransactionSuccess?: (
@@ -82,6 +103,7 @@ interface SubmitSafeTransactionParams {
   address: string;
   datacap: number;
   metaAllocatorContractAddress: `0x${string}`;
+  method: 'add' | 'set';
 }
 
 export const useMetaAllocatorTransaction = ({
@@ -134,7 +156,7 @@ export const useMetaAllocatorTransaction = ({
   }, []);
 
   const submitSafeTransaction = useCallback(
-    async ({ address, datacap, metaAllocatorContractAddress }: SubmitSafeTransactionParams) => {
+    async ({ address, datacap, metaAllocatorContractAddress, method }: SubmitSafeTransactionParams) => {
       setIsPending(true);
       onSubmitSafeTransaction?.();
 
@@ -160,8 +182,8 @@ export const useMetaAllocatorTransaction = ({
 
         const fullDataCap = BigInt(datacap * 1_125_899_906_842_624);
         const data = encodeFunctionData({
-          abi: addAllowanceContractAbi,
-          functionName: 'addAllowance',
+          abi: method === 'add' ? addAllowanceContractAbi : setAllowanceContractAbi,
+          functionName: method === 'add' ? 'addAllowance' : 'setAllowance',
           args: [txAddress as `0x${string}`, fullDataCap],
         });
 

--- a/src/hooks/useMetaAllocatorTransaction.ts
+++ b/src/hooks/useMetaAllocatorTransaction.ts
@@ -156,7 +156,12 @@ export const useMetaAllocatorTransaction = ({
   }, []);
 
   const submitSafeTransaction = useCallback(
-    async ({ address, datacap, metaAllocatorContractAddress, method }: SubmitSafeTransactionParams) => {
+    async ({
+      address,
+      datacap,
+      metaAllocatorContractAddress,
+      method,
+    }: SubmitSafeTransactionParams) => {
       setIsPending(true);
       onSubmitSafeTransaction?.();
 

--- a/src/hooks/useProposeRKHTransaction.ts
+++ b/src/hooks/useProposeRKHTransaction.ts
@@ -1,6 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
 import { useAccount } from '@/hooks';
-import { Application } from '@/types/application';
 import { useCallback } from 'react';
 
 interface UseProposeRKHTransactionProps {
@@ -12,6 +11,7 @@ interface UseProposeRKHTransactionProps {
 interface ProposeTransactionParams {
   address: string;
   datacap: number;
+  additionalDataCap?: bigint;
 }
 
 export function useProposeRKHTransaction({
@@ -23,9 +23,11 @@ export function useProposeRKHTransaction({
 
   const mutation = useMutation({
     mutationKey: ['proposeTransaction'],
-    mutationFn: async ({ address, datacap }: ProposeTransactionParams) => {
+    mutationFn: async ({ address, datacap, additionalDataCap }: ProposeTransactionParams) => {
       onProposeTransaction?.();
-      return proposeAddVerifier(address, datacap);
+      return additionalDataCap
+        ? proposeAddVerifier(address, datacap, additionalDataCap)
+        : proposeAddVerifier(address, datacap);
     },
     onSuccess: (messageId: string) => {
       onProposeTransactionSuccess?.(messageId);
@@ -44,10 +46,11 @@ export function useProposeRKHTransaction({
   });
 
   const proposeTransaction = useCallback(
-    async (params: Pick<Application, 'address' | 'datacap'>) =>
+    async (params: ProposeTransactionParams) =>
       mutation.mutateAsync({
         address: params.address,
         datacap: params.datacap,
+        additionalDataCap: params.additionalDataCap,
       }),
     [mutation],
   );

--- a/src/providers/AccountProvider.tsx
+++ b/src/providers/AccountProvider.tsx
@@ -382,13 +382,13 @@ export const AccountProvider: React.FC<{
         env.useTestnet,
       );
 
-      const datacap = await (api as any).client.stateVerifierStatus(actorId, null)
+      const datacap = await (api as any).client.stateVerifierStatus(actorId, null);
       const datacapInPiB = BigInt(datacap.toString()) / BigInt(1_125_899_906_842_624);
 
       return {
         datacap: Number(datacapInPiB),
         verifier: actorId,
-      }
+      };
     },
     [account],
   );

--- a/src/providers/AccountProvider.tsx
+++ b/src/providers/AccountProvider.tsx
@@ -382,8 +382,7 @@ export const AccountProvider: React.FC<{
         env.useTestnet,
       );
 
-      const head = await (api as any).client.chainHead()
-      const datacap = await (api as any).client.stateVerifierStatus(actorId, head.Cids)
+      const datacap = await (api as any).client.stateVerifierStatus(actorId, null)
       const datacapInPiB = BigInt(datacap.toString()) / BigInt(1_125_899_906_842_624);
 
       return {

--- a/src/providers/AccountProvider.tsx
+++ b/src/providers/AccountProvider.tsx
@@ -368,6 +368,32 @@ export const AccountProvider: React.FC<{
     [account, currentConnector],
   );
 
+  const checkActorDataCap = useCallback(
+    async (actorId: string) => {
+      if (!account?.wallet) {
+        throw new Error('Wallet not connected');
+      }
+
+      const api = new VerifyAPI(
+        VerifyAPI.browserProvider(env.rpcUrl, {
+          token: async () => 'dummy-token',
+        }),
+        account.wallet,
+        env.useTestnet,
+      );
+
+      const head = await (api as any).client.chainHead()
+      const datacap = await (api as any).client.stateVerifierStatus(actorId, head.Cids)
+      const datacapInPiB = BigInt(datacap.toString()) / BigInt(1_125_899_906_842_624);
+
+      return {
+        datacap: Number(datacapInPiB),
+        verifier: actorId,
+      }
+    },
+    [account],
+  );
+
   return (
     <QueryClientProvider client={queryClient}>
       <AccountContext.Provider
@@ -381,6 +407,7 @@ export const AccountProvider: React.FC<{
           acceptVerifierProposal,
           loadPersistedAccount,
           selectedMetaAllocator,
+          checkActorDataCap,
         }}
       >
         {children}

--- a/src/providers/AccountProvider.tsx
+++ b/src/providers/AccountProvider.tsx
@@ -168,7 +168,7 @@ export const AccountProvider: React.FC<{
   }, [account, currentConnector]);
 
   const proposeAddVerifier = useCallback(
-    async (verifierAddress: string, datacap: number) => {
+    async (verifierAddress: string, datacap: number, additionalDataCap: bigint = 0n) => {
       if (!account?.wallet) {
         throw new Error('Wallet not connected');
       }
@@ -182,7 +182,7 @@ export const AccountProvider: React.FC<{
       );
 
       // 1PiB is 2^50
-      const fullDataCap = BigInt(datacap * 1_125_899_906_842_624);
+      const fullDataCap = BigInt(datacap * 1_125_899_906_842_624) + additionalDataCap;
       let verifierAccountId = verifierAddress;
       if (verifierAccountId.length < 12) {
         verifierAccountId = await api.actorKey(verifierAccountId);
@@ -383,10 +383,9 @@ export const AccountProvider: React.FC<{
       );
 
       const datacap = await (api as any).client.stateVerifierStatus(actorId, null);
-      const datacapInPiB = BigInt(datacap.toString()) / BigInt(1_125_899_906_842_624);
 
       return {
-        datacap: Number(datacapInPiB),
+        datacap: BigInt(datacap),
         verifier: actorId,
       };
     },

--- a/src/types/refresh.ts
+++ b/src/types/refresh.ts
@@ -21,6 +21,7 @@ interface User {
 }
 
 export interface Refresh {
+  actorId: string;
   githubIssueId: number;
   githubIssueNumber: number;
   title: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "target": "ES2020",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
RKH flow:

- It is impossible to `add` allowance to contract using `addVerifier` method without onchain changes, so I proposed a workaround. When user selects `Add`, I sum current datacap of the contract and input value. Then I use this sum to `proposeAddVerifier`.

Allocator flow:
- Since it was super easy, I added this also for automated allocators (all I needed was to add one ABI).

[edit]
- I decided not to convert the initial value obtained from RPC (it is now added as a bigint, passed through the function and added at the end of the process).
- Value is converted only for display purpose with rounded value to not break the layout